### PR TITLE
Fix C89 compiler warnings with clang.

### DIFF
--- a/src/chd.c
+++ b/src/chd.c
@@ -599,6 +599,7 @@ void cdlz_codec_free(void* codec)
 
 chd_error cdlz_codec_decompress(void *codec, const uint8_t *src, uint32_t complen, uint8_t *dest, uint32_t destlen)
 {
+	uint8_t *sector;
 	cdlz_codec_data* cdlz = (cdlz_codec_data*)codec;
 
 	// determine header bytes
@@ -623,7 +624,7 @@ chd_error cdlz_codec_decompress(void *codec, const uint8_t *src, uint32_t comple
 		memcpy(&dest[framenum * CD_FRAME_SIZE + CD_MAX_SECTOR_DATA], &cdlz->buffer[frames * CD_MAX_SECTOR_DATA + framenum * CD_MAX_SUBCODE_DATA], CD_MAX_SUBCODE_DATA);
 
 		// reconstitute the ECC data and sync header
-		uint8_t *sector = &dest[framenum * CD_FRAME_SIZE];
+		sector = (uint8_t *)&dest[framenum * CD_FRAME_SIZE];
 		if ((src[framenum / 8] & (1 << (framenum % 8))) != 0)
 		{
 			memcpy(sector, s_cd_sync_header, sizeof(s_cd_sync_header));
@@ -658,6 +659,7 @@ void cdzl_codec_free(void *codec)
 
 chd_error cdzl_codec_decompress(void *codec, const uint8_t *src, uint32_t complen, uint8_t *dest, uint32_t destlen)
 {
+	uint8_t *sector;
 	cdzl_codec_data* cdzl = (cdzl_codec_data*)codec;
 	
 	// determine header bytes
@@ -682,7 +684,7 @@ chd_error cdzl_codec_decompress(void *codec, const uint8_t *src, uint32_t comple
 		memcpy(&dest[framenum * CD_FRAME_SIZE + CD_MAX_SECTOR_DATA], &cdzl->buffer[frames * CD_MAX_SECTOR_DATA + framenum * CD_MAX_SUBCODE_DATA], CD_MAX_SUBCODE_DATA);
 
 		// reconstitute the ECC data and sync header
-		uint8_t *sector = &dest[framenum * CD_FRAME_SIZE];
+		sector = (uint8_t *)&dest[framenum * CD_FRAME_SIZE];
 		if ((src[framenum / 8] & (1 << (framenum % 8))) != 0)
 		{
 			memcpy(sector, s_cd_sync_header, sizeof(s_cd_sync_header));


### PR DESCRIPTION
When building `libchdr` with clang and `C89_BUILD=1` using the RetroArch build system printed these warnings. This PR attempts to correctly fix them, please review to make sure this is correct. I would prefer to make these changes upstream before having libchdr in libretro-common diverge from upstream.
```
    libretro-common/formats/libchdr/chd.c:639:12: warning: ISO C90 forbids mixing declarations and code [-Wdeclaration-after-statement]
                    uint8_t *sector = &dest[framenum * CD_FRAME_SIZE];
                             ^
    libretro-common/formats/libchdr/chd.c:723:12: warning: ISO C90 forbids mixing declarations and code [-Wdeclaration-after-statement]
                    uint8_t *sector = &dest[framenum * CD_FRAME_SIZE];
                             ^
```