### PR TITLE
Backport C89 build fixes from libretro-common.

### DIFF
--- a/src/cdrom.c
+++ b/src/cdrom.c
@@ -63,8 +63,6 @@ void CLIB_DECL logerror(const char *text, ...) ATTR_PRINTF(1,2);
 #define LOG(x)
 #endif
 
-
-
 /***************************************************************************
     CONSTANTS
 ***************************************************************************/
@@ -90,8 +88,6 @@ void CLIB_DECL logerror(const char *text, ...) ATTR_PRINTF(1,2);
 #define ECC_Q_NUM_BYTES 52
 /** @brief  43 bytes each. */
 #define ECC_Q_COMP 43
-
-
 
 /**
  * @brief   -------------------------------------------------
@@ -300,7 +296,6 @@ static const uint16_t qoffsets[ECC_Q_NUM_BYTES][ECC_Q_COMP] =
 	{ 0x867,0x003,0x05b,0x0b3,0x10b,0x163,0x1bb,0x213,0x26b,0x2c3,0x31b,0x373,0x3cb,0x423,0x47b,0x4d3,0x52b,0x583,0x5db,0x633,0x68b,0x6e3,0x73b,0x793,0x7eb,0x843,0x89b,0x037,0x08f,0x0e7,0x13f,0x197,0x1ef,0x247,0x29f,0x2f7,0x34f,0x3a7,0x3ff,0x457,0x4af,0x507,0x55f }
 };
 
-
 /*-------------------------------------------------
  *  ecc_source_byte - return data from the sector
  *  at the given offset, masking anything
@@ -330,8 +325,9 @@ static inline uint8_t ecc_source_byte(const uint8_t *sector, uint32_t offset)
 
 void ecc_compute_bytes(const uint8_t *sector, const uint16_t *row, int rowlen, uint8_t *val1, uint8_t *val2)
 {
+	int component;
 	*val1 = *val2 = 0;
-	for (int component = 0; component < rowlen; component++)
+	for (component = 0; component < rowlen; component++)
 	{
 		*val1 ^= ecc_source_byte(sector, row[component]);
 		*val2 ^= ecc_source_byte(sector, row[component]);
@@ -355,8 +351,9 @@ void ecc_compute_bytes(const uint8_t *sector, const uint16_t *row, int rowlen, u
 
 int ecc_verify(const uint8_t *sector)
 {
+	int byte;
 	/* first verify P bytes */
-	for (int byte = 0; byte < ECC_P_NUM_BYTES; byte++)
+	for (byte = 0; byte < ECC_P_NUM_BYTES; byte++)
 	{
 		uint8_t val1, val2;
 		ecc_compute_bytes(sector, poffsets[byte], ECC_P_COMP, &val1, &val2);
@@ -365,7 +362,7 @@ int ecc_verify(const uint8_t *sector)
 	}
 
 	/* then verify Q bytes */
-	for (int byte = 0; byte < ECC_Q_NUM_BYTES; byte++)
+	for (byte = 0; byte < ECC_Q_NUM_BYTES; byte++)
 	{
 		uint8_t val1, val2;
 		ecc_compute_bytes(sector, qoffsets[byte], ECC_Q_COMP, &val1, &val2);
@@ -388,12 +385,13 @@ int ecc_verify(const uint8_t *sector)
 
 void ecc_generate(uint8_t *sector)
 {
+	int byte;
 	/* first verify P bytes */
-	for (int byte = 0; byte < ECC_P_NUM_BYTES; byte++)
+	for (byte = 0; byte < ECC_P_NUM_BYTES; byte++)
 		ecc_compute_bytes(sector, poffsets[byte], ECC_P_COMP, &sector[ECC_P_OFFSET + byte], &sector[ECC_P_OFFSET + ECC_P_NUM_BYTES + byte]);
 
 	/* then verify Q bytes */
-	for (int byte = 0; byte < ECC_Q_NUM_BYTES; byte++)
+	for (byte = 0; byte < ECC_Q_NUM_BYTES; byte++)
 		ecc_compute_bytes(sector, qoffsets[byte], ECC_Q_COMP, &sector[ECC_Q_OFFSET + byte], &sector[ECC_Q_OFFSET + ECC_Q_NUM_BYTES + byte]);
 }
 


### PR DESCRIPTION
Some C89 build fixes backported from libretro-common and tested using `C89_BUILD=1` with the RetroArch build system.
```
libretro-common/formats/libchdr/flac.c: In function ‘flac_decoder_metadata_callback_static’:
libretro-common/formats/libchdr/flac.c:248:27: error: invalid initializer
  flac_decoder fldecoder = (flac_decoder *)(client_data);
                           ^
libretro-common/formats/libchdr/flac.c:248:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
  flac_decoder fldecoder = (flac_decoder *)(client_data);
  ^~~~~~~~~~~~
libretro-common/formats/libchdr/flac.c:249:11: error: invalid type argument of ‘->’ (have ‘flac_decoder {aka struct _flac_decoder}’)
  fldecoder->sample_rate = metadata->data.stream_info.sample_rate;
           ^~
libretro-common/formats/libchdr/flac.c:250:11: error: invalid type argument of ‘->’ (have ‘flac_decoder {aka struct _flac_decoder}’)
  fldecoder->bits_per_sample = metadata->data.stream_info.bits_per_sample;
           ^~
libretro-common/formats/libchdr/flac.c:251:11: error: invalid type argument of ‘->’ (have ‘flac_decoder {aka struct _flac_decoder}’)
  fldecoder->channels = metadata->data.stream_info.channels;
           ^~
make: *** [Makefile:164: obj-unix/./libretro-common/formats/libchdr/flac.o] Error 1
```
```
libretro-common/formats/libchdr/flac.c: In function ‘flac_decoder_write_callback’:
libretro-common/formats/libchdr/flac.c:285:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
  int shift = decoder->uncompressed_swap ? 8 : 0;
  ^~~
libretro-common/formats/libchdr/flac.c:290:3: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
   for (int sampnum = 0; sampnum < blocksize && decoder->uncompressed_offset < decoder->uncompressed_length; sampnum++, decoder->uncompressed_offset++)
   ^~~
libretro-common/formats/libchdr/flac.c:290:3: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
libretro-common/formats/libchdr/flac.c:291:4: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
    for (int chan = 0; chan < frame->header.channels; chan++)
    ^~~
libretro-common/formats/libchdr/flac.c:298:3: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
   for (int sampnum = 0; sampnum < blocksize && decoder->uncompressed_offset < decoder->uncompressed_length; sampnum++, decoder->uncompressed_offset++)
   ^~~
libretro-common/formats/libchdr/flac.c:299:4: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
    for (int chan = 0; chan < frame->header.channels; chan++)
    ^~~
make: *** [Makefile:162: obj-unix/./libretro-common/formats/libchdr/flac.o] Error 1
```
```
libretro-common/formats/libchdr/cdrom.c: In function ‘ecc_compute_bytes’:
libretro-common/formats/libchdr/cdrom.c:337:2: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
  for (int component = 0; component < rowlen; component++)
  ^~~
libretro-common/formats/libchdr/cdrom.c:337:2: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
make: *** [Makefile:162: obj-unix/./libretro-common/formats/libchdr/cdrom.o] Error 1
```
```
libretro-common/formats/libchdr/cdrom.c: In function ‘ecc_verify’:
libretro-common/formats/libchdr/cdrom.c:363:2: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
  for (int byte = 0; byte < ECC_P_NUM_BYTES; byte++)
  ^~~
libretro-common/formats/libchdr/cdrom.c:363:2: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
libretro-common/formats/libchdr/cdrom.c:372:11: error: redefinition of ‘byte’
  for (int byte = 0; byte < ECC_Q_NUM_BYTES; byte++)
           ^~~~
libretro-common/formats/libchdr/cdrom.c:363:11: note: previous definition of ‘byte’ was here
  for (int byte = 0; byte < ECC_P_NUM_BYTES; byte++)
           ^~~~
libretro-common/formats/libchdr/cdrom.c:372:2: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
  for (int byte = 0; byte < ECC_Q_NUM_BYTES; byte++)
  ^~~
make: *** [Makefile:162: obj-unix/./libretro-common/formats/libchdr/cdrom.o] Error 1
```
```
libretro-common/formats/libchdr/cdrom.c: In function ‘ecc_generate’:
libretro-common/formats/libchdr/cdrom.c:392:2: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
  for (int byte = 0; byte < ECC_P_NUM_BYTES; byte++)
  ^~~
libretro-common/formats/libchdr/cdrom.c:392:2: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
libretro-common/formats/libchdr/cdrom.c:396:11: error: redefinition of ‘byte’
  for (int byte = 0; byte < ECC_Q_NUM_BYTES; byte++)
           ^~~~
libretro-common/formats/libchdr/cdrom.c:392:11: note: previous definition of ‘byte’ was here
  for (int byte = 0; byte < ECC_P_NUM_BYTES; byte++)
           ^~~~
libretro-common/formats/libchdr/cdrom.c:396:2: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
  for (int byte = 0; byte < ECC_Q_NUM_BYTES; byte++)
  ^~~
make: *** [Makefile:163: obj-unix/./libretro-common/formats/libchdr/cdrom.o] Error 1
```