### PR TITLE
Some cleanups and corrections

### DIFF
--- a/src/chd.c
+++ b/src/chd.c
@@ -1766,6 +1766,7 @@ static UINT32 header_guess_unitbytes(chd_file *chd)
 	if (chd_get_metadata(chd, CDROM_OLD_METADATA_TAG, 0, metadata, sizeof(metadata), NULL, NULL, NULL) == CHDERR_NONE ||
 		chd_get_metadata(chd, CDROM_TRACK_METADATA_TAG, 0, metadata, sizeof(metadata), NULL, NULL, NULL) == CHDERR_NONE ||
 		chd_get_metadata(chd, CDROM_TRACK_METADATA2_TAG, 0, metadata, sizeof(metadata), NULL, NULL, NULL) == CHDERR_NONE ||
+		chd_get_metadata(chd, GDROM_OLD_METADATA_TAG, 0, metadata, sizeof(metadata), NULL, NULL, NULL) == CHDERR_NONE ||
 		chd_get_metadata(chd, GDROM_TRACK_METADATA_TAG, 0, metadata, sizeof(metadata), NULL, NULL, NULL) == CHDERR_NONE)
 		return CD_FRAME_SIZE;
 

--- a/src/chd.c
+++ b/src/chd.c
@@ -60,8 +60,6 @@
 
 #define SHA1_DIGEST_SIZE 20
 
-#define CHD_MAKE_TAG(a,b,c,d)       (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
-
 /***************************************************************************
     DEBUGGING
 ***************************************************************************/
@@ -791,12 +789,6 @@ chd_error cdfl_codec_decompress(void *codec, const uint8_t *src, uint32_t comple
     CODEC INTERFACES
 ***************************************************************************/
 
-#define CHD_MAKE_TAG(a,b,c,d)       (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
-
-/* general codecs with CD frontend */
-#define CHD_CODEC_CD_ZLIB CHD_MAKE_TAG('c','d','z','l')
-#define CHD_CODEC_CD_LZMA CHD_MAKE_TAG('c','d','l','z')
-#define CHD_CODEC_CD_FLAC CHD_MAKE_TAG('c','d','f','l')
 
 static const codec_interface codec_interfaces[] =
 {

--- a/src/chd.h
+++ b/src/chd.h
@@ -219,33 +219,34 @@ extern "C" {
 #define CHD_MDFLAGS_CHECKSUM		0x01		/* indicates data is checksummed */
 
 /* standard hard disk metadata */
-#define HARD_DISK_METADATA_TAG		0x47444444	/* 'GDDD' */
+#define HARD_DISK_METADATA_TAG		CHD_MAKE_TAG('G','D','D','D')
 #define HARD_DISK_METADATA_FORMAT	"CYLS:%d,HEADS:%d,SECS:%d,BPS:%d"
 
 /* hard disk identify information */
-#define HARD_DISK_IDENT_METADATA_TAG 0x49444e54 /* 'IDNT' */
+#define HARD_DISK_IDENT_METADATA_TAG CHD_MAKE_TAG('I','D','N','T')
 
 /* hard disk key information */
-#define HARD_DISK_KEY_METADATA_TAG	0x4b455920  /* 'KEY '  */
+#define HARD_DISK_KEY_METADATA_TAG	CHD_MAKE_TAG('K','E','Y',' ')
 
 /* pcmcia CIS information */
-#define PCMCIA_CIS_METADATA_TAG		0x43495320  /* 'CIS '  */
+#define PCMCIA_CIS_METADATA_TAG		CHD_MAKE_TAG('C','I','S',' ')
 
 /* standard CD-ROM metadata */
-#define CDROM_OLD_METADATA_TAG		0x43484344	/* 'CHCD' */
-#define CDROM_TRACK_METADATA_TAG	0x43485452	/* 'CHTR' */
+#define CDROM_OLD_METADATA_TAG		CHD_MAKE_TAG('C','H','C','D')
+#define CDROM_TRACK_METADATA_TAG	CHD_MAKE_TAG('C','H','T','R')
 #define CDROM_TRACK_METADATA_FORMAT	"TRACK:%d TYPE:%s SUBTYPE:%s FRAMES:%d"
-#define CDROM_TRACK_METADATA2_TAG	0x43485432	/* 'CHT2' */
+#define CDROM_TRACK_METADATA2_TAG	CHD_MAKE_TAG('C','H','T','2')
 #define CDROM_TRACK_METADATA2_FORMAT	"TRACK:%d TYPE:%s SUBTYPE:%s FRAMES:%d PREGAP:%d PGTYPE:%s PGSUB:%s POSTGAP:%d"
-#define GDROM_TRACK_METADATA_TAG	0x43484744	/* 'CHTD' */
+#define GDROM_OLD_METADATA_TAG		CHD_MAKE_TAG('C','H','G','T')
+#define GDROM_TRACK_METADATA_TAG	CHD_MAKE_TAG('C', 'H', 'G', 'D')
 #define GDROM_TRACK_METADATA_FORMAT	"TRACK:%d TYPE:%s SUBTYPE:%s FRAMES:%d PAD:%d PREGAP:%d PGTYPE:%s PGSUB:%s POSTGAP:%d"
 
 /* standard A/V metadata */
-#define AV_METADATA_TAG				0x41564156	/* 'AVAV' */
+#define AV_METADATA_TAG				CHD_MAKE_TAG('A','V','A','V')
 #define AV_METADATA_FORMAT			"FPS:%d.%06d WIDTH:%d HEIGHT:%d INTERLACED:%d CHANNELS:%d SAMPLERATE:%d"
 
 /* A/V laserdisc frame metadata */
-#define AV_LD_METADATA_TAG			0x41564C44	/* 'AVLD' */
+#define AV_LD_METADATA_TAG			CHD_MAKE_TAG('A','V','L','D')
 
 /* CHD open values */
 #define CHD_OPEN_READ				1

--- a/src/chd.h
+++ b/src/chd.h
@@ -194,11 +194,18 @@ extern "C" {
 #define CHDFLAGS_IS_WRITEABLE		0x00000002
 #define CHDFLAGS_UNDEFINED			0xfffffffc
 
+#define CHD_MAKE_TAG(a,b,c,d)       (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
+
 /* compression types */
 #define CHDCOMPRESSION_NONE			0
 #define CHDCOMPRESSION_ZLIB			1
 #define CHDCOMPRESSION_ZLIB_PLUS	2
 #define CHDCOMPRESSION_AV			3
+
+/* general codecs with CD frontend */
+#define CHD_CODEC_CD_ZLIB CHD_MAKE_TAG('c','d','z','l')
+#define CHD_CODEC_CD_LZMA CHD_MAKE_TAG('c','d','l','z')
+#define CHD_CODEC_CD_FLAC CHD_MAKE_TAG('c','d','f','l')
 
 /* A/V codec configuration parameters */
 #define AV_CODEC_COMPRESS_CONFIG	1


### PR DESCRIPTION
Moved the CHD_MAKE_TAG() define to the header file and remove the duplicate entry.
Also used CHD_MAKE_TAG() where appropriate instead of "magic numbers" in the header.

According to the source of MAME I added ``GDROM_OLD_METADATA_TAG`` and changed ``GDROM_TRACK_METADATA_TAG`` to ``'CHGD'`` instead of ``'CHTD'`` (see https://github.com/mamedev/mame/blob/9f1c61b8df566d081e19908e1a1b57a716a1f5b3/src/lib/util/chd.h#L230 for reference).