### PR TITLE
Support standard zlib compression

### DIFF
--- a/src/chd.c
+++ b/src/chd.c
@@ -825,6 +825,17 @@ static const codec_interface codec_interfaces[] =
 		NULL
 	},
 
+	/* V5 zlib compression */
+	{
+		CHD_CODEC_ZLIB,
+		"zlib (Deflate)",
+		FALSE,
+		zlib_codec_init,
+		zlib_codec_free,
+		zlib_codec_decompress,
+		NULL
+	},
+
 	/* V5 CD zlib compression */
 	{
 		CHD_CODEC_CD_ZLIB,

--- a/src/chd.h
+++ b/src/chd.h
@@ -202,10 +202,11 @@ extern "C" {
 #define CHDCOMPRESSION_ZLIB_PLUS	2
 #define CHDCOMPRESSION_AV			3
 
+#define CHD_CODEC_ZLIB				CHD_MAKE_TAG('z','l','i','b')
 /* general codecs with CD frontend */
-#define CHD_CODEC_CD_ZLIB CHD_MAKE_TAG('c','d','z','l')
-#define CHD_CODEC_CD_LZMA CHD_MAKE_TAG('c','d','l','z')
-#define CHD_CODEC_CD_FLAC CHD_MAKE_TAG('c','d','f','l')
+#define CHD_CODEC_CD_ZLIB			CHD_MAKE_TAG('c','d','z','l')
+#define CHD_CODEC_CD_LZMA			CHD_MAKE_TAG('c','d','l','z')
+#define CHD_CODEC_CD_FLAC			CHD_MAKE_TAG('c','d','f','l')
 
 /* A/V codec configuration parameters */
 #define AV_CODEC_COMPRESS_CONFIG	1


### PR DESCRIPTION
It's possible to compress CHDv5 with ``chdman`` using "zlib" as the compression format (not just "cdzl").
The codec is the same as the standard zlib compression.

I also corrected the indentation in the header file.