### PR TITLE
add a pkg-config file and install the shared lib and its headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,24 @@ cmake_minimum_required(VERSION 3.1)
 
 project(chdr C)
 
+set(CHDR_VERSION_MAJOR 0)
+set(CHDR_VERSION_MINOR 0)
+
 option(BUILD_SHARED_LIBS "Build libchdr also as a shared library" ON)
 option(WITH_SYSTEM_FLAC "Use system provided FLAC library" OFF)
 option(WITH_SYSTEM_ZLIB "Use system provided zlib library" OFF)
 
 include(FindPkgConfig)
+
+if (NOT DEFINED CMAKE_INSTALL_PREFIX)
+  set(CMAKE_INSTALL_PREFIX "/usr/local")
+endif()
+if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+if (NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
+  set(CMAKE_INSTALL_INCLUDEDIR "include")
+endif()
 
 #--------------------------------------------------
 # dependencies
@@ -19,8 +32,8 @@ set(CRYPTO_SOURCES
 
 if (WITH_SYSTEM_FLAC)
   pkg_check_modules(FLAC REQUIRED flac)
-  list(APPEND CHDR_INCLUDES ${FLAC_INCLUDE_DIRS})
-  list(APPEND CHDR_LIBS ${FLAC_LINK_LIBRARIES})
+  list(APPEND PLATFORM_INCLUDES ${FLAC_INCLUDE_DIRS})
+  list(APPEND PLATFORM_LIBS ${FLAC_LIBRARIES})
 else()
   set(WITH_OGG OFF CACHE BOOL "ogg support (default: test for libogg)")
   set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
@@ -78,7 +91,7 @@ set(LZMA_SOURCES
   #deps/lzma-16.04/C/XzDec.c
   #deps/lzma-16.04/C/XzEnc.c
   #deps/lzma-16.04/C/XzIn.c
-				)
+)
 
 add_library(lzma-static STATIC ${LZMA_SOURCES})
 target_compile_options(lzma-static PRIVATE -D_7ZIP_ST)
@@ -88,8 +101,8 @@ list(APPEND CHDR_LIBS lzma-static)
 # zlib
 if (WITH_SYSTEM_ZLIB)
   pkg_check_modules(ZLIB REQUIRED zlib)
-  list(APPEND CHDR_INCLUDES ${ZLIB_INCLUDE_DIRS})
-  list(APPEND CHDR_LIBS ${ZLIB_LINK_LIBRARIES})
+  list(APPEND PLATFORM_INCLUDES ${ZLIB_INCLUDE_DIRS})
+  list(APPEND PLATFORM_LIBS ${ZLIB_LIBRARIES})
 else()
   add_subdirectory(deps/zlib-1.2.11 EXCLUDE_FROM_ALL)
   list(APPEND CHDR_INCLUDES deps/zlib-1.2.11 ${CMAKE_CURRENT_BINARY_DIR}/deps/zlib-1.2.11)
@@ -111,16 +124,33 @@ set(CHDR_SOURCES
   src/flac.c
   src/flac.h
   src/huffman.c
-  src/huffman.h)
+  src/huffman.h
+)
 
 add_library(chdr-static STATIC ${CHDR_SOURCES})
-target_include_directories(chdr-static PRIVATE ${CHDR_INCLUDES})
+target_include_directories(chdr-static PRIVATE ${CHDR_INCLUDES} ${PLATFORM_INCLUDES})
 target_compile_definitions(chdr-static PRIVATE ${CHDR_DEFS})
-target_link_libraries(chdr-static ${CHDR_LIBS})
+target_link_libraries(chdr-static ${CHDR_LIBS} ${PLATFORM_LIBS})
 
 if (BUILD_SHARED_LIBS)
-  add_library(chdr-shared SHARED ${CHDR_SOURCES})
-  target_include_directories(chdr-shared PRIVATE ${CHDR_INCLUDES})
-  target_compile_definitions(chdr-shared PRIVATE ${CHDR_DEFS})
-  target_link_libraries(chdr-shared ${CHDR_LIBS})
+  set(LIBS ${PLATFORM_LIBS})
+  list(TRANSFORM LIBS PREPEND "-l")
+  list(JOIN LIBS " " LIBS)
+
+  add_library(chdr SHARED ${CHDR_SOURCES})
+  target_include_directories(chdr PRIVATE ${CHDR_INCLUDES} ${PLATFORM_INCLUDES})
+  target_compile_definitions(chdr PRIVATE ${CHDR_DEFS})
+  target_link_libraries(chdr ${CHDR_LIBS} ${PLATFORM_LIBS})
+
+  set_target_properties(chdr PROPERTIES PUBLIC_HEADER "src/chd.h;src/coretypes.h")
+  set_target_properties(chdr PROPERTIES VERSION "${CHDR_VERSION_MAJOR}.${CHDR_VERSION_MINOR}")
+  install(TARGETS chdr
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libchdr"
+  )
+
+  configure_file(pkg-config.pc.in ${CMAKE_BINARY_DIR}/libchdr.pc @ONLY)
+  install(FILES ${CMAKE_BINARY_DIR}/libchdr.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
+

--- a/pkg-config.pc.in
+++ b/pkg-config.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/libchdr
+
+Name: libchdr
+Description: Standalone library for reading MAME's CHDv1-v5 formats
+Version: @CHDR_VERSION_MAJOR@.@CHDR_VERSION_MINOR@
+Libs: -L${libdir} -lchdr @LIBS@
+Cflags: -I${includedir}
+


### PR DESCRIPTION
As libchdr is gaining popularity within the libretro community, it would be nice to be able to install it to the system and use it as a shared lib.

This installs the library, its headers and a pkg-config file as well as sets a version.

You may want to set the version to something other than 0.0 if you go along with this. Also, not sure how many headers are needed but the few libretro cores I've looked at only imported `chd.h`.