### PR TITLE
ship the cdrom.h header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ if (BUILD_SHARED_LIBS)
   target_compile_definitions(chdr PRIVATE ${CHDR_DEFS})
   target_link_libraries(chdr ${CHDR_LIBS} ${PLATFORM_LIBS})
 
-  set_target_properties(chdr PROPERTIES PUBLIC_HEADER "src/chd.h;src/coretypes.h")
+  set_target_properties(chdr PROPERTIES PUBLIC_HEADER "src/cdrom.h;src/chd.h;src/coretypes.h")
   set_target_properties(chdr PROPERTIES VERSION "${CHDR_VERSION_MAJOR}.${CHDR_VERSION_MINOR}")
   install(TARGETS chdr
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"


### PR DESCRIPTION
It looks like the genesis-plus-gx core also needs the cdrom.h header. However there is one difference between their version and yours. In theirs, `CD_TRACK_PADDING` is defined and equal to 4, whereas in yours it is an `extern const`.

I tried defining it when building against the system lib here: https://github.com/alucryd/Genesis-Plus-GX/commit/86fca17227ee1ee629a04126c77805b18cdc7718, while it does build successfully, loading any CHD immediately crashes. I'm probably doing it wrong and will look up how extern const should be used. 

This define is the only obvious difference I spotted by just compiling. It might be something else entirely though I'll try to diff their version and your next week.