### PR TITLE
Fix building on MSVC 2019

### DIFF
--- a/src/coretypes.h
+++ b/src/coretypes.h
@@ -4,6 +4,11 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef _MSC_VER
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #define ARRAY_LENGTH(x) (sizeof(x)/sizeof(x[0]))
 
 typedef uint64_t UINT64;


### PR DESCRIPTION
Fixes #25 by adding a typedef for `ssize_t`. Tested on VS 2019 on W10.