### PR TITLE
Expose chd_open_file in public API

### DIFF
--- a/include/libchdr/chd.h
+++ b/include/libchdr/chd.h
@@ -358,6 +358,7 @@ struct _chd_verify_result
 
 /* open an existing CHD file */
 chd_error chd_open(const char *filename, int mode, chd_file *parent, chd_file **chd);
+chd_error chd_open_file(core_file *file, int mode, chd_file *parent, chd_file **chd);
 
 /* precache underlying file */
 chd_error chd_precache(chd_file *chd);


### PR DESCRIPTION
This allows users to read/access files which have been opened externally by the caller.