### PR TITLE
Support chd parent/clone loading

### DIFF
--- a/include/libchdr/chd.h
+++ b/include/libchdr/chd.h
@@ -392,6 +392,8 @@ CHD_EXPORT const char *chd_error_string(chd_error err);
 /* return a pointer to the extracted CHD header data */
 CHD_EXPORT const chd_header *chd_get_header(chd_file *chd);
 
+/* read CHD header data from file into the pointed struct */
+chd_error chd_read_header(const char *filename, chd_header *header);
 
 
 

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1757,6 +1757,41 @@ CHD_EXPORT const chd_header *chd_get_header(chd_file *chd)
 	return &chd->header;
 }
 
+/*-------------------------------------------------
+    chd_read_header - read CHD header data
+	from file into the pointed struct
+-------------------------------------------------*/
+chd_error chd_read_header(const char *filename, chd_header *header)
+{
+	chd_error err = CHDERR_NONE;
+	chd_file chd;
+
+	/* punt if NULL */
+	if (filename == NULL || header == NULL)
+		EARLY_EXIT(err = CHDERR_INVALID_PARAMETER);
+
+	/* open the file */
+	chd.file = core_fopen(filename);
+	if (chd.file == NULL)
+		EARLY_EXIT(err = CHDERR_FILE_NOT_FOUND);
+
+	/* attempt to read the header */
+	err = header_read(&chd, header);
+	if (err != CHDERR_NONE)
+		EARLY_EXIT(err);
+
+	/* validate the header */
+	err = header_validate(header);
+	if (err != CHDERR_NONE)
+		EARLY_EXIT(err);
+
+cleanup:
+	if (chd.file != NULL)
+		core_fclose(chd.file);
+
+	return err;
+}
+
 /***************************************************************************
     CORE DATA READ/WRITE
 ***************************************************************************/

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1383,8 +1383,15 @@ CHD_EXPORT chd_error chd_open_file(core_file *file, int mode, chd_file *parent, 
 		EARLY_EXIT(err = CHDERR_UNSUPPORTED_VERSION);
 
 	/* if we need a parent, make sure we have one */
-	if (parent == NULL && (newchd->header.flags & CHDFLAGS_HAS_PARENT))
-		EARLY_EXIT(err = CHDERR_REQUIRES_PARENT);
+	if (parent == NULL)
+	{
+		/* Detect parent requirement for versions below 5 */
+		if (newchd->header.version < 5 && newchd->header.flags & CHDFLAGS_HAS_PARENT)
+			EARLY_EXIT(err = CHDERR_REQUIRES_PARENT);
+		/* Detection for version 5 and above - if parentsha1 != 0, we have a parent */
+		else if (newchd->header.version >= 5 && memcmp(nullsha1, newchd->header.parentsha1, sizeof(newchd->header.parentsha1)) != 0)
+			EARLY_EXIT(err = CHDERR_REQUIRES_PARENT);
+	}
 
 	/* make sure we have a valid parent */
 	if (parent != NULL)

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1764,7 +1764,7 @@ CHD_EXPORT const chd_header *chd_get_header(chd_file *chd)
     chd_read_header - read CHD header data
 	from file into the pointed struct
 -------------------------------------------------*/
-chd_error chd_read_header(const char *filename, chd_header *header)
+CHD_EXPORT chd_error chd_read_header(const char *filename, chd_header *header)
 {
 	chd_error err = CHDERR_NONE;
 	chd_file chd;


### PR DESCRIPTION
Fixes #17 

I tried to not touch the chd_file, so there are some ugly workarounds and a small calculation every read.

Block offset recorded in CHD is in units instead of hunks, so if it's not aligned to units_in_hunk, the parent hunk to be read will be split between two hunks. Since there is no cache for chd_file, parent read might potentially read twice when all parent hunks are not aligned (one for first/second half, one for second/third half, and so on).

This implementation actually works with children of a child, that is:

Original -> Child -> Grandchild

or even:

Disc 1 -> Mod of Disc 1
\\-> Disc 2  -> Mod of Disc 2

For grandchildren, a small modification is needed for chdman. It currently only loads one child via command line argument. mamedev/mame#7594

This was tested with PPSSPP and PCSX2, even with grandchildren, though with PPSSPP, using CDLZ actually makes stutters slightly longer compared to CDZL/ciso.

Sorry, this was done in July, but I hadn't had time to clean this for a pull request. Hope it's a good Christmas gift to all.

Edit: Credits to r5 (rz5?) for the 2 commits in the commit description.

Edit 2: If someone knows how to remove the first 3 commits from this PR from Github which the wrong user was used, I'd appreciate it. Even force pushing it didn't remove it.