### PR TITLE
cmake: remove processor type detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,27 +22,6 @@ endif()
 include(FindPkgConfig)
 include(GNUInstallDirs)
 
-# Detect processor type.
-if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64")
-  set(CPU_ARCH "x64")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "AMD64")
-  # MSVC x86/x64
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(CPU_ARCH "x64")
-  else()
-    set(CPU_ARCH "x86")
-  endif()
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i386" OR
-       ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i686")
-  set(CPU_ARCH "x86")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
-  set(CPU_ARCH "aarch64")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "armv7-a")
-  set(CPU_ARCH "arm")
-else()
-  message(FATAL_ERROR "Unknown system processor: " ${CMAKE_SYSTEM_PROCESSOR})
-endif()
-
 #--------------------------------------------------
 # dependencies
 #--------------------------------------------------


### PR DESCRIPTION
With a M1 Mac Mini, I have this error :
```
CMake Error at external/libchdr/CMakeLists.txt:43 (message):
  Unknown system processor: arm64
```
While I could add an extra condition to handle this case, I am wondering if having a cpu arch detection is useful as the variable `CPU_ARCH` looks unused.