### PR TITLE
cmake: turn off crt deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ add_library(chdr-static STATIC ${CHDR_SOURCES})
 target_include_directories(chdr-static PRIVATE ${CHDR_INCLUDES} PUBLIC include)
 target_link_libraries(chdr-static PRIVATE ${CHDR_LIBS} ${PLATFORM_LIBS})
 
+if(MSVC)
+  target_compile_definitions(chdr-static PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
+
 if (INSTALL_STATIC_LIBS)
   install(TARGETS chdr-static ${CHDR_LIBS}
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -71,6 +75,7 @@ if (BUILD_SHARED_LIBS)
   if(MSVC)
     target_compile_definitions(chdr PUBLIC "CHD_DLL")
     target_compile_definitions(chdr PRIVATE "CHD_DLL_EXPORTS")
+    target_compile_definitions(chdr PRIVATE _CRT_SECURE_NO_WARNINGS)
   elseif(APPLE)
     target_link_libraries(chdr PRIVATE -Wl,-dead_strip -Wl,-exported_symbol,_chd_*)
   else()


### PR DESCRIPTION
```
src\libchdr_chd.c(1591): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
src\libchdr_chd.c(1785): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
src\libchdr_chd.c(1855): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
src\libchdr_chd.c(1991): warning C4996: 'sscanf': This function or variable may be unsafe. Consider using sscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
```