### PR TITLE
Add support for reading LZMA and FLAC hunks in non-CD CHDs.

### DIFF
--- a/include/libchdr/chd.h
+++ b/include/libchdr/chd.h
@@ -204,6 +204,8 @@ extern "C" {
 
 #define CHD_CODEC_NONE 0
 #define CHD_CODEC_ZLIB				CHD_MAKE_TAG('z','l','i','b')
+#define CHD_CODEC_LZMA				CHD_MAKE_TAG('l','z','m','a')
+#define CHD_CODEC_FLAC				CHD_MAKE_TAG('f','l','a','c')
 /* general codecs with CD frontend */
 #define CHD_CODEC_CD_ZLIB			CHD_MAKE_TAG('c','d','z','l')
 #define CHD_CODEC_CD_LZMA			CHD_MAKE_TAG('c','d','l','z')


### PR DESCRIPTION
Add codec stubs for non-CD LZMA and FLAC compression types.

I was trying to use raw CHDs with some libretro cores and they didn't work.  This is why.