### PR TITLE
use virtual file i/o API which defaults to a stdio wrapper

### DIFF
--- a/include/libchdr/chd.h
+++ b/include/libchdr/chd.h
@@ -372,7 +372,8 @@ struct _chd_verify_result
 /* chd_error chd_create_file(core_file *file, UINT64 logicalbytes, UINT32 hunkbytes, UINT32 compression, chd_file *parent); */
 
 /* open an existing CHD file */
-CHD_EXPORT chd_error chd_open_file(core_file *file, int mode, chd_file *parent, chd_file **chd);
+CHD_EXPORT chd_error chd_open_core_file(core_file *file, int mode, chd_file *parent, chd_file **chd);
+CHD_EXPORT chd_error chd_open_file(FILE *file, int mode, chd_file *parent, chd_file **chd);
 CHD_EXPORT chd_error chd_open(const char *filename, int mode, chd_file *parent, chd_file **chd);
 
 /* precache underlying file */

--- a/include/libchdr/coretypes.h
+++ b/include/libchdr/coretypes.h
@@ -29,36 +29,50 @@ typedef int32_t INT32;
 typedef int16_t INT16;
 typedef int8_t INT8;
 
-#define core_file FILE
-#define core_fopen(file) fopen(file, "rb")
+typedef struct chd_core_file {
+	/*
+	 * arbitrary pointer to data the implementation uses to implement the below functions
+	 */
+	void *argp;
 
-#if defined USE_LIBRETRO_VFS
-	#define core_fseek fseek
-	#define core_ftell ftell
-#elif defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(__WIN64__)
-	#define core_fseek _fseeki64
-	#define core_ftell _ftelli64
-#elif defined(_LARGEFILE_SOURCE) && defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
-	#define core_fseek fseeko64
-	#define core_ftell ftello64
-#elif defined(__PS3__) && !defined(__PSL1GHT__) || defined(__SWITCH__) || defined(__vita__)
-    #define core_fseek(x,y,z) fseek(x,(off_t)y,z)
-    #define core_ftell(x) (off_t)ftell(x)
-#else
-	#define core_fseek fseeko
-	#define core_ftell ftello
-#endif
-#define core_fread(fc, buff, len) fread(buff, 1, len, fc)
-#define core_fclose fclose
+	/*
+	 * return the size of a given file as a 64-bit unsigned integer.
+	 * the position of the file pointer after calling this function is
+	 * undefined because many implementations will seek to the end of the
+	 * file and call ftell.
+	 *
+	 * on error, (UINT64)-1 is returned.
+	 */
+	UINT64(*fsize)(struct chd_core_file*);
 
-static UINT64 core_fsize(core_file *f)
+	/*
+	 * should match the behavior of fread, except the FILE* argument at the end
+	 * will be replaced with a struct chd_core_file*.
+	 */
+	size_t(*fread)(void*,size_t,size_t,struct chd_core_file*);
+
+	// closes the given file.
+	int (*fclose)(struct chd_core_file*);
+
+	// fseek clone
+	int (*fseek)(struct chd_core_file*, long, int);
+} core_file;
+
+static inline int core_fclose(core_file *fp) {
+	return fp->fclose(fp);
+}
+
+static inline size_t core_fread(core_file *fp, void *ptr, size_t len) {
+	return fp->fread(ptr, 1, len, fp);
+}
+
+static inline int core_fseek(core_file* fp, long offset, int whence) {
+	return fp->fseek(fp, offset, whence);
+}
+
+static inline UINT64 core_fsize(core_file *fp)
 {
-    UINT64 rv;
-    UINT64 p = core_ftell(f);
-    core_fseek(f, 0, SEEK_END);
-    rv = core_ftell(f);
-    core_fseek(f, p, SEEK_SET);
-    return rv;
+	return fp->fsize(fp);
 }
 
 #endif


### PR DESCRIPTION
This PR implements a virtual file I/O layer that goes between libchdr and stdio.
Users of libchdr can optionally implement their own file I/O functions instead
of using the stdio ones so that they can load files from more sources than
just simple files.

For example, users can create core_file implementations that load files over a
network connection, or from RAM, from an archive, etc.

Another benefit is that in the future users which require platform-specific behavior
will be able to implement it themselves instead of making changes to libchdr.

For the sake of backwards-compatibility, chd_open_file now accepts a FILE* instead of a core_file*.
Users wishing to provide their own I/O function implementations may do so by calling the new
chd_open_core_file function.