### PR TITLE
fix uninitialized chd_file in chd_read_header

### DIFF
--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1901,7 +1901,7 @@ CHD_EXPORT const chd_header *chd_get_header(chd_file *chd)
 CHD_EXPORT chd_error chd_read_header(const char *filename, chd_header *header)
 {
 	chd_error err = CHDERR_NONE;
-	chd_file chd;
+	chd_file chd = { };
 
 	/* punt if NULL */
 	if (filename == NULL || header == NULL)


### PR DESCRIPTION
at the cleanup label, it checks if chd.file != NULL, but if filename
or header was NULL then chd will be uninitialized

i saw this as a gcc warning while building libchdr.  IDK if it is
causing any problems but it is definitely something that should be fixed.
