### PR TITLE
Fix fseek offset type.

### DIFF
--- a/include/libchdr/coretypes.h
+++ b/include/libchdr/coretypes.h
@@ -55,7 +55,7 @@ typedef struct chd_core_file {
 	int (*fclose)(struct chd_core_file*);
 
 	// fseek clone
-	int (*fseek)(struct chd_core_file*, long, int);
+	int (*fseek)(struct chd_core_file*, INT64, int);
 } core_file;
 
 static inline int core_fclose(core_file *fp) {
@@ -66,7 +66,7 @@ static inline size_t core_fread(core_file *fp, void *ptr, size_t len) {
 	return fp->fread(ptr, 1, len, fp);
 }
 
-static inline int core_fseek(core_file* fp, long offset, int whence) {
+static inline int core_fseek(core_file* fp, INT64 offset, int whence) {
 	return fp->fseek(fp, offset, whence);
 }
 

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -324,7 +324,7 @@ static UINT64 core_stdio_fsize(core_file *file);
 static size_t core_stdio_fread(void *ptr, size_t size, size_t nmemb, core_file *file);
 static int core_stdio_fclose(core_file *file);
 static int core_stdio_fclose_nonowner(core_file *file); // alternate fclose used by chd_open_file
-static int core_stdio_fseek(core_file* file, long offset, int whence);
+static int core_stdio_fseek(core_file* file, INT64 offset, int whence);
 
 /* internal header operations */
 static chd_error header_validate(const chd_header *header);
@@ -2953,6 +2953,6 @@ static int core_stdio_fclose_nonowner(core_file *file) {
 /*-------------------------------------------------
 	core_stdio_fseek - core_file wrapper over fclose
 -------------------------------------------------*/
-static int core_stdio_fseek(core_file* file, long offset, int whence) {
+static int core_stdio_fseek(core_file* file, INT64 offset, int whence) {
 	return core_stdio_fseek_impl((FILE*)file->argp, offset, whence);
 }


### PR DESCRIPTION
Replace `long` with `INT64`, since `long`'s size can vary depending on build environment (Win64 is 4 bytes, Linux/macOS is 8 bytes).