### PR TITLE
Avoid huffman tree buffer overrun in huffman_import_tree_rle

### DIFF
--- a/src/libchdr_huffman.c
+++ b/src/libchdr_huffman.c
@@ -212,6 +212,8 @@ enum huffman_error huffman_import_tree_rle(struct huffman_decoder* decoder, stru
 			else
 			{
 				int repcount = bitstream_read(bitbuf, numbits) + 3;
+				if (repcount + curnode > decoder->numcodes)
+					return HUFFERR_INVALID_DATA;
 				while (repcount--)
 					decoder->huffnode[curnode++].numbits = nodebits;
 			}


### PR DESCRIPTION
I was able to easily trigger a heap corruption on Windows by forcing repcount to the max value. This can happen with corrupted CHDs and it is very similar to a number of crash reports i received.

Issue #90