### PR TITLE
Check mem alloc failures triggered by invalid chd

### DIFF
--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1349,6 +1349,8 @@ static chd_error decompress_v5_map(chd_file* chd, chd_header* header)
 	if (!chd_compressed(header))
 	{
 		header->rawmap = (uint8_t*)malloc(rawmapsize);
+		if (header->rawmap == NULL)
+			return CHDERR_OUT_OF_MEMORY;
 		core_fseek(chd->file, header->mapoffset, SEEK_SET);
 		result = core_fread(chd->file, header->rawmap, rawmapsize);
 		return CHDERR_NONE;
@@ -1366,10 +1368,18 @@ static chd_error decompress_v5_map(chd_file* chd, chd_header* header)
 
 	/* now read the map */
 	compressed_ptr = (uint8_t*)malloc(sizeof(uint8_t) * mapbytes);
+	if (compressed_ptr == NULL)
+		return CHDERR_OUT_OF_MEMORY;
 	core_fseek(chd->file, header->mapoffset + 16, SEEK_SET);
 	result = core_fread(chd->file, compressed_ptr, mapbytes);
 	bitbuf = create_bitstream(compressed_ptr, sizeof(uint8_t) * mapbytes);
 	header->rawmap = (uint8_t*)malloc(rawmapsize);
+	if (header->rawmap == NULL)
+	{
+		free(compressed_ptr);
+		free(bitbuf);
+		return CHDERR_OUT_OF_MEMORY;
+	}
 
 	/* first decode the compression types */
 	decoder = create_huffman_decoder(16, 8);


### PR DESCRIPTION
The chdv5 raw map and rle tree size are read from the header, which may be incorrect if the chd is corrupted, resulting in a malloc failure if huge