### PR TITLE
Add basic GitHub Actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,19 @@
+name: CMake
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release


### PR DESCRIPTION
This will build these 3 targets
- chdr-static (static library)
- chdr (shared library)
- chdr-benchmark (executable)

using 3 different compilers

- AppleClang 14.0.0 (macos-latest)
- GCC 11.3.0 (ubuntu-latest)
- Visual Studio 17 2022 (windows-latest)