### PR TITLE
Fix huff_codec_decompress returned error code

### DIFF
--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -811,7 +811,7 @@ static chd_error huff_codec_decompress(void *codec, const uint8_t *src, uint32_t
 	if (err != HUFFERR_NONE)
 	{
 		free(bitbuf);
-		return err;
+		return CHDERR_DECOMPRESSION_ERROR;
 	}
 
 	// then decode the data


### PR DESCRIPTION
It was returning a huffman_error code but the return type is chd_error, a completely different enum.