### PR TITLE
Fix the huffman decoder memory leak

### DIFF
--- a/src/libchdr_huffman.c
+++ b/src/libchdr_huffman.c
@@ -295,6 +295,9 @@ enum huffman_error huffman_import_tree_huffman(struct huffman_decoder* decoder, 
 		}
 	}
 
+    /* make sure we free the local huffman decoder */
+    delete_huffman_decoder(smallhuff);
+
 	/* make sure we ended up with the right number */
 	if (curcode != decoder->numcodes)
 		return HUFFERR_INVALID_DATA;


### PR DESCRIPTION
Noticed the leak when verifying multiple chds in my app and my linux box would run out of memory.