### PR TITLE
Add GitHub Actions for Switch and Vita

### DIFF
--- a/.github/workflows/switch.yml
+++ b/.github/workflows/switch.yml
@@ -1,0 +1,17 @@
+name: Nintendo Switch
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: devkitpro/devkita64:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/Switch.cmake
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release

--- a/.github/workflows/vita.yml
+++ b/.github/workflows/vita.yml
@@ -1,0 +1,17 @@
+name: PlayStation Vita
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: vitasdk/vitasdk:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${VITASDK}/share/vita.toolchain.cmake
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release


### PR DESCRIPTION
Verify that libchdr builds fine on Switch and Vita as it can be used by multi-platform emulators