### PR TITLE
Make sure all windows.h includes are lowercase

### DIFF
--- a/deps/lzma-22.01/include/Threads.h
+++ b/deps/lzma-22.01/include/Threads.h
@@ -5,7 +5,7 @@
 #define __7Z_THREADS_H
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #else
 
 #if defined(__linux__)

--- a/deps/lzma-22.01/src/Alloc.c
+++ b/deps/lzma-22.01/src/Alloc.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 #include <stdlib.h>
 

--- a/deps/lzma-22.01/src/CpuArch.c
+++ b/deps/lzma-22.01/src/CpuArch.c
@@ -217,7 +217,7 @@ BoolInt CPU_Is_InOrder()
 }
 
 #if !defined(MY_CPU_AMD64) && defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 static BoolInt CPU_Sys_Is_SSE_Supported()
 {
   OSVERSIONINFO vi;
@@ -275,7 +275,7 @@ BoolInt CPU_IsSupported_SHA()
 // #include <stdio.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 BoolInt CPU_IsSupported_AVX2()
@@ -351,7 +351,7 @@ BoolInt CPU_IsSupported_PageGB()
 
 #ifdef _WIN32
 
-#include <Windows.h>
+#include <windows.h>
 
 BoolInt CPU_IsSupported_CRC32()  { return IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE) ? 1 : 0; }
 BoolInt CPU_IsSupported_CRYPTO() { return IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) ? 1 : 0; }


### PR DESCRIPTION
It can cause build failures otherwise when cross-compiling on a case sensitive OS.