### PR TITLE
zstd: disable shared lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ else()
 endif()
 
 # zstd
+option(ZSTD_BUILD_SHARED "BUILD SHARED LIBRARIES" OFF)
 option(ZSTD_BUILD_PROGRAMS "BUILD PROGRAMS" OFF)
 add_subdirectory(deps/zstd-1.5.6/build/cmake EXCLUDE_FROM_ALL)
 list(APPEND CHDR_LIBS libzstd_static)


### PR DESCRIPTION
When trying to build Flycast with libchdr master, I had the following issue:
```
ninja: error: build.ninja:5303: multiple rules generate core/deps/libchdr/deps/zstd-1.5.6/build/cmake/lib/libzstd.a [-w dupbuild=err]
```
This PR fixes that 🙂 