### PR TITLE
fix some (U)INT types stuff

### DIFF
--- a/deps/lzma-24.05/include/7zTypes.h
+++ b/deps/lzma-24.05/include/7zTypes.h
@@ -11,6 +11,7 @@
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 
 #ifndef EXTERN_C_BEGIN
 #ifdef __cplusplus
@@ -172,17 +173,16 @@ typedef unsigned char Byte;
 typedef short Int16;
 typedef unsigned short UInt16;
 
-#ifdef Z7_DECL_Int32_AS_long
-typedef long Int32;
-typedef unsigned long UInt32;
-#else
-typedef int Int32;
-typedef unsigned int UInt32;
-#endif
+typedef int32_t Int32;
+typedef uint32_t UInt32;
 
 
 #ifndef _WIN32
 
+#undef INT
+#undef INT32
+#undef UINT
+#undef UINT32
 typedef int INT;
 typedef Int32 INT32;
 typedef unsigned int UINT;
@@ -529,7 +529,7 @@ struct ISzAlloc
 /*
 #define Z7_CONTAINER_FROM_VTBL_CLS(ptr, type, m) Z7_CONTAINER_FROM_VTBL(ptr, type, m)
 */
-#if defined (__clang__) || defined(__GNUC__)
+#if defined (__clang__) || defined(__GNUC__) && __GNUC__ >= 5
 #define Z7_DIAGNOSTIC_IGNORE_BEGIN_CAST_QUAL \
   _Pragma("GCC diagnostic push") \
   _Pragma("GCC diagnostic ignored \"-Wcast-qual\"")

--- a/include/libchdr/coretypes.h
+++ b/include/libchdr/coretypes.h
@@ -10,14 +10,12 @@
 
 #define ARRAY_LENGTH(x) (sizeof(x)/sizeof(x[0]))
 
-#if defined(__PS3__) || defined(__PSL1GHT__)
 #undef UINT32
 #undef UINT16
 #undef UINT8
 #undef INT32
 #undef INT16
 #undef INT8
-#endif
 
 #define UINT64 uint64_t
 #define UINT32 uint32_t

--- a/include/libchdr/coretypes.h
+++ b/include/libchdr/coretypes.h
@@ -19,15 +19,15 @@
 #undef INT8
 #endif
 
-typedef uint64_t UINT64;
-typedef uint32_t UINT32;
-typedef uint16_t UINT16;
-typedef uint8_t UINT8;
+#define UINT64 uint64_t
+#define UINT32 uint32_t
+#define UINT16 uint16_t
+#define UINT8 uint8_t
 
-typedef int64_t INT64;
-typedef int32_t INT32;
-typedef int16_t INT16;
-typedef int8_t INT8;
+#define INT64 int64_t
+#define INT32 int32_t
+#define INT16 int16_t
+#define INT8 int8_t
 
 typedef struct chd_core_file {
 	/*


### PR DESCRIPTION
While compiling some of the targets for picodrive I ran into compile problems with various of the toolchains wrt to handling of (U)INT types multiply defined in 7ztypes and coretypes. As the structure is at the moment I just had no other idea than to replace that by macros, although I don't believe this is ideal. Shouldn't the core libchdr just use the stdint types instead?