### PR TITLE
zstd: disable legacy support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 # zstd
 option(ZSTD_BUILD_SHARED "BUILD SHARED LIBRARIES" OFF)
 option(ZSTD_BUILD_PROGRAMS "BUILD PROGRAMS" OFF)
+option(ZSTD_LEGACY_SUPPORT "LEGACY SUPPORT" OFF)
 add_subdirectory(deps/zstd-1.5.6/build/cmake EXCLUDE_FROM_ALL)
 list(APPEND CHDR_LIBS libzstd_static)
 #--------------------------------------------------


### PR DESCRIPTION
With ZSTD_LEGACY_SUPPORT disabled, zstd will not be able to decompress files compressed by older versions of zstd (< v0.8.0).

Since zstd codec in chd was introduced recently in mame, with version 1.5.5, we can safely disable legacy support as no chd files must have been generated by an version below 0.8.0.