### PR TITLE
lzma: extends neon support when hwcap is not available

### DIFF
--- a/deps/lzma-24.05/src/CpuArch.c
+++ b/deps/lzma-24.05/src/CpuArch.c
@@ -839,7 +839,7 @@ static unsigned long MY_getauxval(int aux)
   #define MY_HWCAP_CHECK_FUNC(name) \
   BoolInt CPU_IsSupported_ ## name(void) { return 0; }
 
-#if defined(__SWITCH__) || defined(__vita__)
+#if defined(__ARM_NEON)
   BoolInt CPU_IsSupported_NEON(void) { return 1; }
 #else
   MY_HWCAP_CHECK_FUNC(NEON)


### PR DESCRIPTION
`__ARM_NEON` is widely supported than `__SWITCH__` + `__vita__` 🙂 