### PR TITLE
chd: Fix various memory and overflow bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,14 @@ if(BUILD_LTO)
   endif()
 endif()
 
+option(BUILD_FUZZER "Build instrumented binary for fuzzing with libfuzzer, requires clang")
+if(BUILD_FUZZER)
+  # Override CFLAGS early for instrumentation. Disable shared libs for instrumentation.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address,fuzzer-no-link")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,fuzzer-no-link")
+  set(BUILD_SHARED_LIBS OFF)
+endif()
+
 include(GNUInstallDirs)
 
 #--------------------------------------------------

--- a/include/libchdr/huffman.h
+++ b/include/libchdr/huffman.h
@@ -85,6 +85,6 @@ int huffman_build_tree(struct huffman_decoder* decoder, uint32_t totaldata, uint
 enum huffman_error huffman_assign_canonical_codes(struct huffman_decoder* decoder);
 enum huffman_error huffman_compute_tree_from_histo(struct huffman_decoder* decoder);
 
-void huffman_build_lookup_table(struct huffman_decoder* decoder);
+enum huffman_error huffman_build_lookup_table(struct huffman_decoder* decoder);
 
 #endif

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -89,6 +89,11 @@
 
 #define CHD_V1_SECTOR_SIZE			512			/* size of a "sector" in the V1 header */
 
+#define CHD_MAX_HUNK_SIZE				(128 * 1024 * 1024) /* hunk size probably shouldn't be more than 128MB */
+
+/* we're currently only using this for CD/DVDs, if we end up with more than 10GB data, it's probably invalid */
+#define CHD_MAX_FILE_SIZE				(10ULL * 1024 * 1024 * 1024)
+
 #define COOKIE_VALUE				0xbaadf00d
 #define MAX_ZLIB_ALLOCS				64
 
@@ -2528,6 +2533,10 @@ static chd_error header_validate(const chd_header *header)
 			 header->obsolete_heads == 0 || header->obsolete_hunksize == 0))
 			return CHDERR_INVALID_PARAMETER;
 	}
+
+	/* some basic size checks to prevent huge mallocs */
+	if (header->hunkbytes >= CHD_MAX_HUNK_SIZE || ((uint64_t)header->hunkbytes * (uint64_t)header->totalhunks) >= CHD_MAX_FILE_SIZE)
+		return CHDERR_INVALID_PARAMETER;
 
 	return CHDERR_NONE;
 }

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -2365,7 +2365,7 @@ CHD_EXPORT chd_error chd_get_metadata(chd_file *chd, uint32_t searchtag, uint32_
 			uint32_t faux_length;
 
 			/* fill in the faux metadata */
-			sprintf(faux_metadata, HARD_DISK_METADATA_FORMAT, chd->header.obsolete_cylinders, chd->header.obsolete_heads, chd->header.obsolete_sectors, chd->header.hunkbytes / chd->header.obsolete_hunksize);
+			sprintf(faux_metadata, HARD_DISK_METADATA_FORMAT, chd->header.obsolete_cylinders, chd->header.obsolete_heads, chd->header.obsolete_sectors, (chd->header.obsolete_hunksize != 0) ? (chd->header.hunkbytes / chd->header.obsolete_hunksize) : 0);
 			faux_length = (uint32_t)strlen(faux_metadata) + 1;
 
 			/* copy the metadata itself */

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -3144,7 +3144,8 @@ static chd_error metadata_find_entry(chd_file *chd, uint32_t metatag, uint32_t m
 		uint32_t	count;
 
 		/* read the raw header */
-		core_fseek(chd->file, metaentry->offset, SEEK_SET);
+		if (core_fseek(chd->file, metaentry->offset, SEEK_SET) != 0)
+			break;
 		count = core_fread(chd->file, raw_meta_header, sizeof(raw_meta_header));
 		if (count != sizeof(raw_meta_header))
 			break;

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1632,13 +1632,17 @@ static chd_error decompress_v5_map(chd_file* chd, chd_header* header)
 	uint8_t rawbuf[16];
 	struct huffman_decoder* decoder;
 	enum huffman_error err;
-	uint64_t curoffset;	
+	uint64_t curoffset;
+	const uint64_t file_size = core_fsize(chd->file);
 	int rawmapsize = map_size_v5(header);
 	if (rawmapsize < 0)
 		return CHDERR_INVALID_FILE;
 
 	if (!chd_compressed(header))
 	{
+		if ((header->mapoffset + rawmapsize) >= file_size || (header->mapoffset + rawmapsize) < header->mapoffset)
+			return CHDERR_INVALID_FILE;
+
 		header->rawmap = (uint8_t*)malloc(rawmapsize);
 		if (header->rawmap == NULL)
 			return CHDERR_OUT_OF_MEMORY;
@@ -1658,6 +1662,8 @@ static chd_error decompress_v5_map(chd_file* chd, chd_header* header)
 	parentbits = rawbuf[14];
 
 	/* now read the map */
+	if ((header->mapoffset + mapbytes) < header->mapoffset || (header->mapoffset + mapbytes) >= file_size)
+		return CHDERR_INVALID_FILE;
 	compressed_ptr = (uint8_t*)malloc(sizeof(uint8_t) * mapbytes);
 	if (compressed_ptr == NULL)
 		return CHDERR_OUT_OF_MEMORY;

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -299,6 +299,7 @@ struct _chd_file
 	uint32_t					cookie;			/* cookie, should equal COOKIE_VALUE */
 
 	core_file *				file;			/* handle to the open core file */
+	uint64_t				file_size;		/* size of the core file */
 	chd_header				header;			/* header, extracted from file */
 
 	chd_file *				parent;			/* pointer to parent file, or NULL */
@@ -1633,14 +1634,13 @@ static chd_error decompress_v5_map(chd_file* chd, chd_header* header)
 	struct huffman_decoder* decoder;
 	enum huffman_error err;
 	uint64_t curoffset;
-	const uint64_t file_size = core_fsize(chd->file);
 	int rawmapsize = map_size_v5(header);
 	if (rawmapsize < 0)
 		return CHDERR_INVALID_FILE;
 
 	if (!chd_compressed(header))
 	{
-		if ((header->mapoffset + rawmapsize) >= file_size || (header->mapoffset + rawmapsize) < header->mapoffset)
+		if ((header->mapoffset + rawmapsize) >= chd->file_size || (header->mapoffset + rawmapsize) < header->mapoffset)
 			return CHDERR_INVALID_FILE;
 
 		header->rawmap = (uint8_t*)malloc(rawmapsize);
@@ -1662,7 +1662,7 @@ static chd_error decompress_v5_map(chd_file* chd, chd_header* header)
 	parentbits = rawbuf[14];
 
 	/* now read the map */
-	if ((header->mapoffset + mapbytes) < header->mapoffset || (header->mapoffset + mapbytes) >= file_size)
+	if ((header->mapoffset + mapbytes) < header->mapoffset || (header->mapoffset + mapbytes) >= chd->file_size)
 		return CHDERR_INVALID_FILE;
 	compressed_ptr = (uint8_t*)malloc(sizeof(uint8_t) * mapbytes);
 	if (compressed_ptr == NULL)
@@ -1862,6 +1862,9 @@ CHD_EXPORT chd_error chd_open_core_file(core_file *file, int mode, chd_file *par
 	newchd->cookie = COOKIE_VALUE;
 	newchd->parent = parent;
 	newchd->file = file;
+	newchd->file_size = core_fsize(file);
+	if ((int64_t)newchd->file_size <= 0)
+		EARLY_EXIT(err = CHDERR_INVALID_FILE);
 
 	/* now attempt to read the header */
 	err = header_read(newchd, &newchd->header);
@@ -2064,19 +2067,15 @@ cleanup:
 CHD_EXPORT chd_error chd_precache(chd_file *chd)
 {
 	int64_t count;
-	uint64_t size;
 
 	if (chd->file_cache == NULL)
 	{
-		size = core_fsize(chd->file);
-		if ((int64_t)size <= 0)
-			return CHDERR_INVALID_DATA;
-		chd->file_cache = malloc(size);
+		chd->file_cache = malloc(chd->file_size);
 		if (chd->file_cache == NULL)
 			return CHDERR_OUT_OF_MEMORY;
 		core_fseek(chd->file, 0, SEEK_SET);
-		count = core_fread(chd->file, chd->file_cache, size);
-		if (count != size)
+		count = core_fread(chd->file, chd->file_cache, chd->file_size);
+		if (count != chd->file_size)
 		{
 			free(chd->file_cache);
 			chd->file_cache = NULL;
@@ -2723,7 +2722,10 @@ static uint8_t* hunk_read_compressed(chd_file *chd, uint64_t offset, size_t size
 #endif
 	if (chd->file_cache != NULL)
 	{
-		return chd->file_cache + offset;
+		if ((offset + size) > chd->file_size || (offset + size) < offset)
+			return NULL;
+		else
+			return chd->file_cache + offset;
 	}
 	else
 	{
@@ -2749,6 +2751,9 @@ static chd_error hunk_read_uncompressed(chd_file *chd, uint64_t offset, size_t s
 #endif
 	if (chd->file_cache != NULL)
 	{
+		if ((offset + size) > chd->file_size || (offset + size) < offset)
+			return CHDERR_READ_ERROR;
+
 		memcpy(dest, chd->file_cache + offset, size);
 	}
 	else
@@ -3091,7 +3096,7 @@ static chd_error map_read(chd_file *chd)
 	}
 
 	/* verify the length */
-	if (maxoffset > core_fsize(chd->file))
+	if (maxoffset > chd->file_size)
 	{
 		err = CHDERR_INVALID_FILE;
 		goto cleanup;

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1703,7 +1703,16 @@ static chd_error decompress_v5_map(chd_file* chd, chd_header* header)
 			rawmap[0] = lastcomp, repcount--;
 		else
 		{
-			uint8_t val = huffman_decode_one(decoder, bitbuf);
+			uint8_t val;
+			if (bitstream_overflow(bitbuf))
+			{
+				free(compressed_ptr);
+				free(bitbuf);
+				delete_huffman_decoder(decoder);
+				return CHDERR_DECOMPRESSION_ERROR;
+			}
+
+			val = huffman_decode_one(decoder, bitbuf);
 			if (val == COMPRESSION_RLE_SMALL)
 				rawmap[0] = lastcomp, repcount = 2 + huffman_decode_one(decoder, bitbuf);
 			else if (val == COMPRESSION_RLE_LARGE)

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -2729,6 +2729,10 @@ static uint8_t* hunk_read_compressed(chd_file *chd, uint64_t offset, size_t size
 	}
 	else
 	{
+		/* make sure it isn't larger than the compressed buffer */
+		if (size > chd->header.hunkbytes)
+			return NULL;
+
 		core_fseek(chd->file, offset, SEEK_SET);
 		bytes = core_fread(chd->file, chd->compressed, size);
 		if (bytes != size)

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1953,7 +1953,8 @@ CHD_EXPORT chd_error chd_open_core_file(core_file *file, int mode, chd_file *par
 	}
 	else
 	{
-		int decompnum;
+		int decompnum, needsinit;
+
 		/* verify the compression types and initialize the codecs */
 		for (decompnum = 0; decompnum < ARRAY_LENGTH(newchd->header.compression); decompnum++)
 		{
@@ -1970,8 +1971,21 @@ CHD_EXPORT chd_error chd_open_core_file(core_file *file, int mode, chd_file *par
 			if (newchd->codecintf[decompnum] == NULL && newchd->header.compression[decompnum] != 0)
 				EARLY_EXIT(err = CHDERR_UNSUPPORTED_FORMAT);
 
+			/* ensure we don't try to initialize the same codec twice */
+			/* this is "normal" for chds where the user overrides the codecs, it'll have none repeated */
+			needsinit = (newchd->codecintf[decompnum]->init != NULL);
+			for (i = 0; i < decompnum; i++)
+			{
+				if (newchd->codecintf[decompnum] == newchd->codecintf[i])
+				{
+					/* already initialized */
+					needsinit = 0;
+					break;
+				}
+      }
+
 			/* initialize the codec */
-			if (newchd->codecintf[decompnum]->init != NULL)
+			if (needsinit)
 			{
 				void* codec = NULL;
 				switch (newchd->header.compression[decompnum])
@@ -2131,8 +2145,22 @@ CHD_EXPORT void chd_close(chd_file *chd)
 		for (i = 0 ; i < ARRAY_LENGTH(chd->codecintf); i++)
 		{
 			void* codec = NULL;
+			int j, needsfree;
 
 			if (chd->codecintf[i] == NULL)
+				continue;
+
+			/* only free each codec at max once */
+			needsfree = 1;
+			for (j = 0; j < i; j++)
+			{
+				if (chd->codecintf[i] == chd->codecintf[j])
+				{
+					needsfree = 0;
+					break;
+				}
+			}
+			if (!needsfree)
 				continue;
 
 			switch (chd->codecintf[i]->compression)

--- a/src/libchdr_huffman.c
+++ b/src/libchdr_huffman.c
@@ -230,7 +230,9 @@ enum huffman_error huffman_import_tree_rle(struct huffman_decoder* decoder, stru
 		return error;
 
 	/* build the lookup table */
-	huffman_build_lookup_table(decoder);
+	error = huffman_build_lookup_table(decoder);
+	if (error != HUFFERR_NONE)
+		return error;
 
 	/* determine final input length and report errors */
 	return bitstream_overflow(bitbuf) ? HUFFERR_INPUT_BUFFER_TOO_SMALL : HUFFERR_NONE;
@@ -272,7 +274,9 @@ enum huffman_error huffman_import_tree_huffman(struct huffman_decoder* decoder, 
 	error = huffman_assign_canonical_codes(smallhuff);
 	if (error != HUFFERR_NONE)
 		return error;
-	huffman_build_lookup_table(smallhuff);
+	error = huffman_build_lookup_table(smallhuff);
+	if (error != HUFFERR_NONE)
+		return error;
 
 	/* determine the maximum length of an RLE count */
 	temp = decoder->numcodes - 9;
@@ -308,7 +312,9 @@ enum huffman_error huffman_import_tree_huffman(struct huffman_decoder* decoder, 
 		return error;
 
 	/* build the lookup table */
-	huffman_build_lookup_table(decoder);
+	error = huffman_build_lookup_table(decoder);
+	if (error != HUFFERR_NONE)
+		return error;
 
 	/* determine final input length and report errors */
 	return bitstream_overflow(bitbuf) ? HUFFERR_INPUT_BUFFER_TOO_SMALL : HUFFERR_NONE;
@@ -523,8 +529,9 @@ enum huffman_error huffman_assign_canonical_codes(struct huffman_decoder* decode
  *-------------------------------------------------
  */
 
-void huffman_build_lookup_table(struct huffman_decoder* decoder)
+enum huffman_error huffman_build_lookup_table(struct huffman_decoder* decoder)
 {
+	const lookup_value* lookupend = &decoder->lookup[(1u << decoder->maxbits)];
 	uint32_t curcode;
 	/* iterate over all codes */
 	for (curcode = 0; curcode < decoder->numcodes; curcode++)
@@ -533,9 +540,10 @@ void huffman_build_lookup_table(struct huffman_decoder* decoder)
 		struct node_t* node = &decoder->huffnode[curcode];
 		if (node->numbits > 0)
 		{
-         int shift;
-         lookup_value *dest;
-         lookup_value *destend;
+			int shift;
+			lookup_value *dest;
+			lookup_value *destend;
+
 			/* set up the entry */
 			lookup_value value = MAKE_LOOKUP(curcode, node->numbits);
 
@@ -543,8 +551,12 @@ void huffman_build_lookup_table(struct huffman_decoder* decoder)
 			shift = decoder->maxbits - node->numbits;
 			dest = &decoder->lookup[node->bits << shift];
 			destend = &decoder->lookup[((node->bits + 1) << shift) - 1];
+			if (dest >= lookupend || destend >= lookupend || destend < dest)
+				return HUFFERR_INTERNAL_INCONSISTENCY;
 			while (dest <= destend)
 				*dest++ = value;
 		}
 	}
+
+	return HUFFERR_NONE;
 }

--- a/src/libchdr_huffman.c
+++ b/src/libchdr_huffman.c
@@ -273,10 +273,16 @@ enum huffman_error huffman_import_tree_huffman(struct huffman_decoder* decoder, 
 	/* then regenerate the tree */
 	error = huffman_assign_canonical_codes(smallhuff);
 	if (error != HUFFERR_NONE)
+	{
+		delete_huffman_decoder(smallhuff);
 		return error;
+	}
 	error = huffman_build_lookup_table(smallhuff);
 	if (error != HUFFERR_NONE)
+	{
+		delete_huffman_decoder(smallhuff);
 		return error;
+	}
 
 	/* determine the maximum length of an RLE count */
 	temp = decoder->numcodes - 9;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,12 @@
 add_executable(chdr-benchmark benchmark.c)
 target_link_libraries(chdr-benchmark PRIVATE chdr-static)
+
+# fuzzing
+if(BUILD_FUZZER)
+  add_executable(chdr-fuzz fuzz.c)
+  target_link_options(chdr-fuzz PRIVATE "-fsanitize=address,fuzzer")
+  target_link_libraries(chdr-fuzz PRIVATE chdr-static)
+  add_custom_target(fuzz
+    COMMAND "$<TARGET_FILE:chdr-fuzz>" "-max_len=131072"
+    DEPENDS chdr-fuzz)
+endif()

--- a/tests/fuzz.c
+++ b/tests/fuzz.c
@@ -1,0 +1,80 @@
+#include <libchdr/chd.h>
+#include <libchdr/coretypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  const uint8_t *buffer;
+  size_t buffer_size;
+  size_t buffer_pos;
+} membuf;
+
+static uint64_t membuf_fsize(struct chd_core_file *cf) {
+  return ((membuf *)cf->argp)->buffer_size;
+}
+
+static size_t membuf_fread(void *buf, size_t size, size_t count,
+                           struct chd_core_file *cf) {
+  membuf *mb = (membuf *)cf->argp;
+  if ((UINT32_MAX / size) < count)
+    return 0;
+  size_t copy = size * count;
+  size_t remain = mb->buffer_size - mb->buffer_pos;
+  if (remain < copy)
+    copy = remain;
+  memcpy(buf, &mb->buffer[mb->buffer_pos], copy);
+  mb->buffer_pos += copy;
+  return copy;
+}
+
+static int membuf_fclose(struct chd_core_file *cf) { return 0; }
+
+static int membuf_fseek(struct chd_core_file *cf, int64_t pos, int origin) {
+  membuf *mb = (membuf *)cf->argp;
+  if (origin == SEEK_SET) {
+    if (pos < 0 || (size_t)pos > mb->buffer_size)
+      return -1;
+    mb->buffer_pos = (size_t)pos;
+    return 0;
+  } else if (origin == SEEK_CUR) {
+    if (pos < 0 && (size_t)-pos > mb->buffer_pos)
+      return -1;
+    else if ((mb->buffer_pos + (size_t)pos) > mb->buffer_size)
+      return -1;
+    mb->buffer_pos =
+        (pos < 0) ? (mb->buffer_pos - (size_t)-pos) : (mb->buffer_pos + pos);
+    return 0;
+  } else if (origin == SEEK_END) {
+    mb->buffer_pos = mb->buffer_size;
+    return 0;
+  } else {
+    return -1;
+  }
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  unsigned int i;
+  unsigned int totalbytes;
+  void *buffer;
+  membuf mb = {data, size, 0u};
+  struct chd_core_file cf = {&mb, membuf_fsize, membuf_fread, membuf_fclose,
+                             membuf_fseek};
+  chd_file *file;
+  const chd_header *header;
+  chd_error err = chd_open_core_file(&cf, CHD_OPEN_READ, NULL, &file);
+  if (err != CHDERR_NONE)
+    return 0;
+
+  header = chd_get_header(file);
+  totalbytes = header->hunkbytes * header->totalhunks;
+  buffer = malloc(header->hunkbytes);
+  for (i = 0; i < header->totalhunks; i++) {
+    err = chd_read(file, i, buffer);
+    if (err != CHDERR_NONE)
+      continue;
+  }
+  free(buffer);
+  chd_close(file);
+  return 0;
+}


### PR DESCRIPTION
As part of trying to improve the robustness of input file handling for my emulator, I have identified and fixed a number of issues in libchdr's CHD handling. Most of these were discovered through some very brief fuzzing with [LibFuzzer](https://llvm.org/docs/LibFuzzer.html).

The majority are straightforward - missing error checking, or assuming input was structurally valid. **The only one I'm a bit iffy on is d5935ca - is a 128MB maximum hunk size and 10GB data size reasonable?**

It's one of the first things that libfuzzer hit, so I had to add some basic checks, and even if the allocation will fail on most systems. Should you have a corrupted file, you don't really want them to swap out all their working sets to satisfy it, only to fail loading later.

5eb9a28 is related to #118, however it only fixes the malicious/corrupted case, I didn't have any very low-compression CHDs to check with.

I fully acknowledge that many of these would require some serious work to actually accomplish anything malicious with, and many of them are just reads, not writes, but IMO it's best to validate everything where possible, especially when there is basically no performance cost to doing so. And it saves OOM/crashing if the user does have accidental file corruption.

I've included the fuzz target in this PR as well. If that's not something you want upstream, let me know and I'll drop the commit. If anyone wants to spend more time fuzzing the library, simply enable the CMake option and use `make fuzz` to invoke it. You'll probably also need to set `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++` as well on most systems. There are no doubt more data validation issues... :)