### PR TITLE
CHD: Provide file and core_file versions of read_header

### DIFF
--- a/include/libchdr/chd.h
+++ b/include/libchdr/chd.h
@@ -399,6 +399,8 @@ CHD_EXPORT const char *chd_error_string(chd_error err);
 CHD_EXPORT const chd_header *chd_get_header(chd_file *chd);
 
 /* read CHD header data from file into the pointed struct */
+CHD_EXPORT chd_error chd_read_header_core_file(core_file *file, chd_header *header);
+CHD_EXPORT chd_error chd_read_header_file(FILE *file, chd_header *header);
 CHD_EXPORT chd_error chd_read_header(const char *filename, chd_header *header);
 
 

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -2332,34 +2332,78 @@ CHD_EXPORT const chd_header *chd_get_header(chd_file *chd)
     chd_read_header - read CHD header data
 	from file into the pointed struct
 -------------------------------------------------*/
-CHD_EXPORT chd_error chd_read_header(const char *filename, chd_header *header)
+
+CHD_EXPORT chd_error chd_read_header_core_file(core_file *file, chd_header *header)
 {
 	chd_error err = CHDERR_NONE;
 	chd_file chd;
 
-	/* punt if NULL */
-	if (filename == NULL || header == NULL)
-		EARLY_EXIT(err = CHDERR_INVALID_PARAMETER);
+	/* verify parameters */
+	if (file == NULL || header == NULL)
+		return CHDERR_INVALID_PARAMETER;
 
-	/* open the file */
-	chd.file = core_stdio_fopen(filename);
-	if (chd.file == NULL)
-		EARLY_EXIT(err = CHDERR_FILE_NOT_FOUND);
+	chd.file = file;
 
 	/* attempt to read the header */
 	err = header_read(&chd, header);
 	if (err != CHDERR_NONE)
-		EARLY_EXIT(err);
+		return err;
 
 	/* validate the header */
-	err = header_validate(header);
-	if (err != CHDERR_NONE)
-		EARLY_EXIT(err);
+	return header_validate(header);
+}
 
-cleanup:
-	if (chd.file != NULL)
-		core_fclose(chd.file);
+/*-------------------------------------------------
+    chd_read_header - read CHD header data
+	from file into the pointed struct
+-------------------------------------------------*/
 
+CHD_EXPORT chd_error chd_read_header_file(FILE *file, chd_header *header)
+{
+	chd_error err;
+	core_file *stream = malloc(sizeof(core_file));
+	if (!stream)
+		return CHDERR_OUT_OF_MEMORY;
+	stream->argp = file;
+	stream->fsize = core_stdio_fsize;
+	stream->fread = core_stdio_fread;
+	stream->fclose = core_stdio_fclose_nonowner;
+	stream->fseek = core_stdio_fseek;
+
+	err = chd_read_header_core_file(stream, header);
+	core_fclose(stream);
+	return err;
+}
+
+/*-------------------------------------------------
+    chd_read_header - read CHD header data
+	from file into the pointed struct
+-------------------------------------------------*/
+
+CHD_EXPORT chd_error chd_read_header(const char *filename, chd_header *header)
+{
+	chd_error err;
+	core_file *file = NULL;
+
+	if (filename == NULL)
+	{
+		err = CHDERR_INVALID_PARAMETER;
+		goto cleanup;
+	}
+
+	/* open the file */
+	file = core_stdio_fopen(filename);
+	if (file == 0)
+	{
+		err = CHDERR_FILE_NOT_FOUND;
+		goto cleanup;
+	}
+
+	err = chd_read_header_core_file(file, header);
+
+	cleanup:
+	if (file != NULL)
+		core_fclose(file);
 	return err;
 }
 


### PR DESCRIPTION
This PR implements additional variants of `chd_read_header`, allowing the header to be read from a `FILE` handle, or a core_file instance. PCSX2 is already using a similar patch, this PR brings a rewritten version for upstream.

These functions are needed for handling CHD files with parent files using virtual I/O API (or FILE handles), as `chd_open_*` will reject the file if a needed parent isn't provided, leaving `chd_read_header` as the only way to retrieve the parent hash values.

The implementation is based on the existing `chd_open_*` functions as done in https://github.com/rtissera/libchdr/pull/78.