### PR TITLE
 Update CMake Min Requirement to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 
 project(chdr VERSION 0.2 LANGUAGES C)
 


### PR DESCRIPTION
cmake 4.0 has deprecated version 3.9 and lower and started error'ing out when in use. (you can currently get around it by adding -DCMAKE_POLICY_VERSION_MINIMUM=3.5 but thats just a workaround)

updating from 3.9 to 3.10 should be relatively safe and small jump, [policy change](https://cmake.org/cmake/help/v4.0/manual/cmake-policies.7.html#policies-introduced-by-cmake-3-10)