### PR TITLE
ci: update bsd operating systems

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -11,19 +11,19 @@ jobs:
         architecture: [ arm64, x86-64 ]
         include:
           - operating_system: freebsd
-            version: '14.0'
-            pkginstall: sudo pkg install -y cmake git ninja pkgconf
+            version: '14.2'
+            pkginstall: sudo pkg update && sudo pkg install -y cmake git ninja pkgconf
           - operating_system: netbsd
-            version: '10.0'
-            pkginstall: sudo pkgin update && sudo pkgin -y install cmake gcc12 git ninja-build pkgconf && export PATH=/usr/pkg/gcc12/bin:$PATH
+            version: '10.1'
+            pkginstall: sudo pkgin update && sudo pkgin -y install clang cmake git ninja-build pkgconf
           - operating_system: openbsd
-            version: '7.5'
-            pkginstall: sudo pkg_add cmake git ninja pkgconf
+            version: '7.7'
+            pkginstall: sudo pkg_add -u && sudo pkg_add cmake git ninja pkgconf
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cross-platform-actions/action@v0.24.0
+      - uses: cross-platform-actions/action@v0.28.0
         with:
           operating_system: ${{ matrix.operating_system }}
           architecture: ${{ matrix.architecture }}

--- a/deps/lzma-24.05/src/CpuArch.c
+++ b/deps/lzma-24.05/src/CpuArch.c
@@ -799,7 +799,11 @@ BoolInt CPU_IsSupported_AES (void) { return APPLE_CRYPTO_SUPPORT_VAL; }
 
 #ifdef USE_HWCAP
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+  #include <sys/param.h>
+#endif
+
+#if (defined(__FreeBSD__) && __FreeBSD_version >= 1200000) || (defined(__OpenBSD__) && OpenBSD >= 202409)
 static unsigned long MY_getauxval(int aux)
 {
   unsigned long val;


### PR DESCRIPTION
Also add a fix to lzma related to the elf_aux_info function, [only available on FreeBSD 12.0 and OpenBSD 7.6](https://man.openbsd.org/elf_aux_info.3). Without this fix, openbsd arm64 does not compile