### PR TITLE
Release prep for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+All notable changes to libchdr are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - Unreleased
+
+First formally tagged release. Project has been depended on by
+RetroArch, DuckStation, Flycast, SwanStation and others for years;
+this tag exists so Linux distros can ship a stable reference point
+instead of a dated snapshot.
+
+### Added
+
+- CHDv5 read support (backported from MAME C++).
+- Zstandard (zstd) compression codec.
+- `CHDR_WANT_RAW_DATA_SECTOR`, `CHDR_WANT_SUBCODE`,
+  `CHDR_VERIFY_BLOCK_CRC` CMake options for reduced-scope builds.
+- `WITH_SYSTEM_ZLIB` and `WITH_SYSTEM_ZSTD` CMake options for distros.
+- `BUILD_FUZZER` CMake option (libFuzzer + ASan) and `tests/fuzz.c`.
+- `BUILD_LTO` CMake option.
+- `chd_read_header_core_file_callbacks` public API.
+- pkg-config file (`libchdr.pc`) installed alongside the library.
+- Unity-build script (`unity.c`).
+
+### Changed
+
+- Library is now split across per-codec translation units
+  (`src/libchdr_codec_*.c`) instead of one monolithic `libchdr_chd.c`.
+- Internal codec headers moved from `include/libchdr/` to `src/` so
+  they are no longer part of the installed header set (#144).
+- `cd_codec_decompress` signature is now stable across builds; it no
+  longer changes with the `WANT_SUBCODE` preprocessor flag (#144).
+- `lzma_allocator` now embeds `ISzAlloc` as its first member, matching
+  the LZMA SDK's expected layout (#144).
+- Bundled `zlib` replaced with `miniz` 3.1.1 (single-file).
+- Bundled `zstd` replaced with a single-file version of itself
+  (1.5.7).
+- Bundled LZMA updated to 25.01.
+- Bundled `dr_flac` updated to 0.13.3 (includes fix for
+  CVE-2025-14369 integer overflow).
+- pkg-config `Version:` now emits the full `MAJOR.MINOR.PATCH`.
+- Exported symbols are restricted to `chd_*` via a linker version
+  script on ELF targets, `-exported_symbol _chd_*` on macOS.
+
+### Fixed
+
+- `chd_read_header_core_file_callbacks` now works for CHD versions
+  below 4 (#146).
+- v1/v2 header: `hunkbytes` is computed in `uint64_t` and rejected if
+  the product of `seclen * obsolete_hunksize` overflows `uint32_t` or
+  is zero (#148).
+- `metadata_find_entry` caps traversal at 65536 entries, preventing
+  unbounded seek+read loops on malformed CHDs with cyclic
+  `next`-pointer chains (#148).
+- `fseeko` / `ftello` are now declared under strict C11 builds
+  (`-Werror=implicit-function-declaration`) and on Debian armhf
+  `time64` rebuilds: feature test macros are defined before any
+  system header include, and the `fseeko64`/`ftello64` branch has
+  been removed in favor of LFS-aliased `fseeko`/`ftello` (#92, #117).
+- `chd_get_metadata` fallback now uses `snprintf` instead of
+  `sprintf`.
+- `fseek` errors are now propagated as `CHDERR_READ_ERROR`.
+- Only reads as much header data as the declared header length.
+- Various memory and overflow bugs in hunk decoding (#132).
+
+### Removed
+
+- Bundled `zlib-1.3.1/` directory (dead since the switch to miniz).
+
+## ABI
+
+`SOVERSION = PROJECT_VERSION_MAJOR`. Bumped only on ABI breaks. The
+`v0.x` series ships as `libchdr.so.0`; a future `v1.0.0` would ship
+as `libchdr.so.1`. The public header set is restricted to
+`include/libchdr/` and the public symbol set to `chd_*`.
+
+[0.3.0]: https://github.com/rtissera/libchdr/releases/tag/v0.3.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(chdr VERSION 0.2 LANGUAGES C)
+project(chdr VERSION 0.3.0 LANGUAGES C)
 
 if(CMAKE_PROJECT_NAME STREQUAL "chdr")
   option(BUILD_SHARED_LIBS "Build libchdr also as a shared library" ON)

--- a/pkg-config.pc.in
+++ b/pkg-config.pc.in
@@ -4,7 +4,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/libchdr
 
 Name: libchdr
 Description: Standalone library for reading MAME's CHDv1-v5 formats
-Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@
+Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lchdr @LIBS@
 Cflags: -I${includedir}
 

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1452,7 +1452,7 @@ CHD_EXPORT chd_error chd_get_metadata(chd_file *chd, uint32_t searchtag, uint32_
 			uint32_t faux_length;
 
 			/* fill in the faux metadata */
-			sprintf(faux_metadata, HARD_DISK_METADATA_FORMAT, chd->header.obsolete_cylinders, chd->header.obsolete_heads, chd->header.obsolete_sectors, (chd->header.obsolete_hunksize != 0) ? (chd->header.hunkbytes / chd->header.obsolete_hunksize) : 0);
+			snprintf(faux_metadata, sizeof(faux_metadata), HARD_DISK_METADATA_FORMAT, chd->header.obsolete_cylinders, chd->header.obsolete_heads, chd->header.obsolete_sectors, (chd->header.obsolete_hunksize != 0) ? (chd->header.hunkbytes / chd->header.obsolete_hunksize) : 0);
 			faux_length = (uint32_t)strlen(faux_metadata) + 1;
 
 			/* copy the metadata itself */


### PR DESCRIPTION
## Summary

Pre-release housekeeping so the repo can be tagged `v0.3.0` and picked up by Linux distros.

- **Bump `project(chdr VERSION)` from 0.2 to 0.3.0.** First formally tagged release (the repo has ~350 commits and zero tags). `SOVERSION` stays `0`, so Debian `libchdr0` / SONAME `libchdr.so.0` are unchanged — no distro package rename.
- **pkg-config emits full `PROJECT_VERSION`** (`MAJOR.MINOR.PATCH`) so downstreams can pin against patch releases, not just `0.3`.
- **`chd_get_metadata` fallback: `snprintf`** instead of `sprintf` when filling the 256-byte synthesized hard-disk metadata buffer. Current inputs fit, but `sprintf` into a bounded stack buffer is a review wart — harden.

## Verified

- [x] `cmake --build` clean
- [x] `libchdr.pc` → `Version: 0.3.0`
- [x] Shared lib symlink chain: `libchdr.so` → `libchdr.so.0` → `libchdr.so.0.3`
- [x] No ABI change vs `master`

## Companion PRs

- #148 — Harden CHD header parser against malformed input (uint32 overflow + metadata cycle)

Once both merge, tag `v0.3.0` and `gh release create v0.3.0 --generate-notes`.