### PR TITLE
Fix fseeko/ftello under strict C and time64 rebuilds

### DIFF
--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -37,6 +37,19 @@
 
 ***************************************************************************/
 
+/* Feature test macros: must come before any system header.
+ * Ensures fseeko/ftello are declared under strict C99/C11 and
+ * that 64-bit file offsets are used on 32-bit platforms (armhf,
+ * i386, and other time64/LFS rebuilds). */
+#if !defined(_WIN32) && !defined(__PS3__) && !defined(__SWITCH__) && !defined(__vita__)
+#  ifndef _POSIX_C_SOURCE
+#    define _POSIX_C_SOURCE 200809L
+#  endif
+#  ifndef _FILE_OFFSET_BITS
+#    define _FILE_OFFSET_BITS 64
+#  endif
+#endif
+
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -2127,13 +2140,13 @@ static uint64_t core_stdio_fsize(void *file) {
 #elif defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(__WIN64__)
 	#define core_stdio_fseek_impl _fseeki64
 	#define core_stdio_ftell_impl _ftelli64
-#elif defined(_LARGEFILE_SOURCE) && defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
-	#define core_stdio_fseek_impl fseeko64
-	#define core_stdio_ftell_impl ftello64
 #elif defined(__PS3__) && !defined(__PSL1GHT__) || defined(__SWITCH__) || defined(__vita__)
 	#define core_stdio_fseek_impl(x,y,z) fseek(x,(off_t)y,z)
 	#define core_stdio_ftell_impl(x) (off_t)ftell(x)
 #else
+	/* With _FILE_OFFSET_BITS=64 defined at the top of this TU, glibc
+	 * aliases fseeko/ftello to the 64-bit variants, so no *64 suffix
+	 * is needed. This is also the time64-safe spelling on armhf. */
 	#define core_stdio_fseek_impl fseeko
 	#define core_stdio_ftell_impl ftello
 #endif


### PR DESCRIPTION
## Summary

Two related 32-bit Linux build failures long carried as out-of-tree patches by Debian:

- **Strict C11 + no extensions** (`-Wimplicit-function-declaration`): `fseeko` / `ftello` were not declared because no feature test macro was set before `<stdio.h>` was included. Reported in #92.
- **Debian armhf time64 rebuild**: the previous preprocessor branch expected `_LARGEFILE64_SOURCE`-gated `fseeko64` / `ftello64`, which glibc no longer exports in the time64 profile. Reported in #117.

## Fix

- Define `_POSIX_C_SOURCE=200809L` and `_FILE_OFFSET_BITS=64` at the top of `libchdr_chd.c` (before any system header include).
- Drop the `fseeko64`/`ftello64` branch. With `_FILE_OFFSET_BITS=64`, glibc aliases `fseeko`/`ftello` to the 64-bit variants, which is also the time64-safe spelling on 32-bit Debian.

Platform-specific branches (Windows `_fseeki64`, PS3/Switch/Vita) are preserved and excluded from the feature-macro block.

## Test plan

- [x] `cmake -DCMAKE_C_STANDARD=11 -DCMAKE_C_EXTENSIONS=OFF -DCMAKE_C_FLAGS="-Werror=implicit-function-declaration"` — clean build (regression test for #92)
- [x] Default build on Linux x86_64 — clean
- [x] CI: Windows / macOS / BSD / Haiku / Switch / Vita
- [ ] Ask Debian maintainer (a-detiste) to drop the out-of-tree patch and rebuild against this

## Motivation

Lets distros drop out-of-tree patches. Blocks tagging `v0.3.0`.

Closes #92.
Closes #117.