### PR TITLE
Add fuzz corpus generator

### DIFF
--- a/tests/corpus/.gitignore
+++ b/tests/corpus/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!README.md
+!generate.sh
+!fetch.sh

--- a/tests/corpus/README.md
+++ b/tests/corpus/README.md
@@ -1,0 +1,37 @@
+# Fuzz Corpus
+
+Seed inputs for `chdr-fuzz` (built with `-DBUILD_FUZZER=ON`).
+
+This directory is gitignored except for the scripts below. Populate it
+before running the fuzzer.
+
+## Generate synthetic CHDv5 samples (fast, reproducible)
+
+Requires `chdman` (from MAME) in `$PATH`.
+
+    ./generate.sh
+
+Produces tiny CHDs (each < 100 KB) covering:
+
+- CHD types: raw, hard disk, CD-ROM
+- Compression codecs: none, zlib, lzma, huff, flac, zstd, cdzl, cdlz,
+  cdfl, cdzs
+
+All outputs are CHDv5 — modern `chdman` emits v5 exclusively.
+
+## Fetch real CHDv4 samples (optional)
+
+    ./fetch.sh
+
+Downloads a small set of publicly redistributable CHDv4 test images.
+Skipped if network access is unavailable.
+
+Generated `.chd` files land under `tests/corpus/seeds/`, which is
+gitignored. The scripts and this README live at `tests/corpus/` and
+are tracked.
+
+## Run the fuzzer
+
+    cmake -B build -DBUILD_FUZZER=ON -DCMAKE_C_COMPILER=clang
+    cmake --build build --target chdr-fuzz
+    ./build/tests/chdr-fuzz -max_len=131072 tests/corpus/seeds

--- a/tests/corpus/fetch.sh
+++ b/tests/corpus/fetch.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Optional: fetch small publicly redistributable CHDv4 samples.
+# The modern chdman only emits CHDv5, so this supplements generate.sh
+# with legacy-format coverage for the fuzz corpus.
+set -euo pipefail
+
+CORPUS="$(cd "$(dirname "$0")" && pwd)/seeds"
+mkdir -p "$CORPUS"
+
+fetch () {
+    local url="$1" out="$2"
+    if [ -f "$CORPUS/$out" ]; then
+        echo "  $out: already present"
+        return
+    fi
+    if curl -fsSL --max-time 30 -o "$CORPUS/$out" "$url"; then
+        echo "  $out: ok ($(stat -c%s "$CORPUS/$out") bytes)"
+    else
+        echo "  $out: fetch failed — skipping"
+        rm -f "$CORPUS/$out"
+    fi
+}
+
+# Add trusted small-CHDv4 URLs here when identified.
+# Intentionally empty at the start; contributors can add sources that
+# are small (< 1 MiB), publicly redistributable, and pin a known hash.
+echo "(no CHDv4 sources configured yet — edit tests/corpus/fetch.sh)"

--- a/tests/corpus/generate.sh
+++ b/tests/corpus/generate.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Generate a tiny CHDv5 fuzz corpus spanning all codec combos.
+# Requires: chdman (from MAME), dd, mktemp.
+set -euo pipefail
+
+CORPUS="$(cd "$(dirname "$0")" && pwd)/seeds"
+mkdir -p "$CORPUS"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! command -v chdman >/dev/null; then
+    echo "chdman not found in PATH" >&2
+    exit 1
+fi
+
+# Tiny raw payload: 64 KiB of zeros + a few deterministic bytes.
+# Small enough to fuzz fast, large enough to exercise multi-hunk paths.
+RAW_HD="$TMP/tiny.img"
+dd if=/dev/zero of="$RAW_HD" bs=512 count=128 status=none
+printf 'LIBCHDR-FUZZ-CORPUS' | dd of="$RAW_HD" bs=1 seek=0 conv=notrunc status=none
+
+# Minimal CUE+BIN (single audio track, 1 second = 75 frames of 2352 B).
+CUE="$TMP/tiny.cue"
+BIN="$TMP/tiny.bin"
+dd if=/dev/urandom of="$BIN" bs=2352 count=75 status=none
+cat > "$CUE" <<EOF
+FILE "tiny.bin" BINARY
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+EOF
+
+# Raw for createraw (power-of-two, small).
+RAW="$TMP/tiny.raw"
+dd if=/dev/urandom of="$RAW" bs=4096 count=16 status=none
+
+create_hd () {
+    local name="$1"; shift
+    chdman createhd -f -o "$CORPUS/$name" -i "$RAW_HD" --chs 4,16,2 -ss 512 "$@" >/dev/null 2>&1 || true
+}
+
+create_cd () {
+    local name="$1"; shift
+    chdman createcd -f -o "$CORPUS/$name" -i "$CUE" "$@" >/dev/null 2>&1 || true
+}
+
+create_raw () {
+    local name="$1"; shift
+    chdman createraw -f -o "$CORPUS/$name" -i "$RAW" -hs 4096 -us 512 "$@" >/dev/null 2>&1 || true
+}
+
+# Hard disk: default codecs + flavor variants.
+create_hd hd_default.chd
+create_hd hd_none.chd       -c none
+create_hd hd_zlib.chd       -c zlib
+create_hd hd_lzma.chd       -c lzma
+create_hd hd_huff.chd       -c huff
+create_hd hd_zstd.chd       -c zstd
+create_hd hd_multi.chd      -c zlib,lzma,huff,zstd
+
+# CD-ROM: default + per-codec.
+create_cd cd_default.chd
+create_cd cd_none.chd       -c none
+create_cd cd_cdzl.chd       -c cdzl
+create_cd cd_cdlz.chd       -c cdlz
+create_cd cd_cdfl.chd       -c cdfl
+create_cd cd_cdzs.chd       -c cdzs
+
+# Raw.
+create_raw raw_default.chd
+create_raw raw_none.chd     -c none
+create_raw raw_zstd.chd     -c zstd
+
+# Summary.
+echo "generated $(ls -1 "$CORPUS"/*.chd 2>/dev/null | wc -l) CHD samples:"
+ls -lhS "$CORPUS"/*.chd 2>/dev/null | awk '{print "  " $5 "  " $NF}' | sed "s|$CORPUS/||"


### PR DESCRIPTION
## Summary

Adds \`tests/corpus/\` — a scratch directory for seeding \`chdr-fuzz\` (\`-DBUILD_FUZZER=ON\`). Nothing is built or linked; this is purely tooling + docs. Generated \`.chd\` files are never committed.

- **\`generate.sh\`**: shells out to \`chdman\` to produce a tiny CHDv5 corpus covering all chd types (raw, HD, CD) and all codecs (none, zlib, lzma, huff, zstd, cdzl, cdlz, cdfl, cdzs). Total output ~1.5 MiB into \`tests/corpus/seeds/\`; HD samples are as small as 255 bytes, CD samples ~180 KiB each. 16 samples.
- **\`fetch.sh\`**: placeholder for adding publicly redistributable CHDv4 samples. Modern \`chdman\` only emits CHDv5, so real CHDv4 coverage requires fetching real files — left intentionally empty for contributors to fill with trusted sources.
- **\`README.md\`**: invocation notes.
- **\`.gitignore\`**: ignores everything except the four tracked files above.

## Verified locally

\`\`\`
./tests/corpus/generate.sh    # 16 .chd in tests/corpus/seeds/
cmake -B build -DBUILD_FUZZER=ON -DCMAKE_C_COMPILER=clang
cmake --build build --target chdr-fuzz
build/tests/chdr-fuzz -runs=0 tests/corpus/seeds
# -> 20 files loaded, coverage 1031 edges / 1884 features, no crashes
\`\`\`

## Motivation

Pre-release fuzz coverage for tagging \`v0.3.0\`. Complements the
hardening in #148 by giving the fuzzer real seed inputs so libFuzzer
starts with useful coverage instead of random noise.

## Follow-ups (not in this PR)

- Populate \`fetch.sh\` with trusted small CHDv4 samples.
- Consider wiring CTest to run \`chdr-fuzz -runs=N seeds\` as a regression test.