### PR TITLE
CHANGELOG: document AVHuff as known limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ instead of a dated snapshot.
 
 - Bundled `zlib-1.3.1/` directory (dead since the switch to miniz).
 
+### Known limitations
+
+- **AVHuff codec is not implemented** (#69). CHDs produced with the
+  `CHDCOMPRESSION_AV` codec (CHDv1-v4) or the `avhu` codec tag (CHDv5)
+  return `CHDERR_UNSUPPORTED_FORMAT`. In practice this only affects
+  laserdisc CHDs (Dragon's Lair, Space Ace, Time Traveler, and other
+  MAME/Daphne/Hypseus Singe targets). All other consumers (PS1, PS2,
+  Saturn, Dreamcast, arcade HD, etc.) are unaffected.
+
 ## ABI
 
 `SOVERSION = PROJECT_VERSION_MAJOR`. Bumped only on ABI breaks. The


### PR DESCRIPTION
Follow-up to #149. The AVHuff codec (CHDv1-v4 \`CHDCOMPRESSION_AV\` and CHDv5 \`avhu\` tag) is not implemented in libchdr and returns \`CHDERR_UNSUPPORTED_FORMAT\`. Scope is laserdisc CHDs only — niche enough that it was never a blocker for existing consumers (RetroArch, DuckStation, Flycast, etc.), but worth calling out explicitly now that the library is being tagged for distro packaging.

Adds a "Known limitations" section under \`[0.3.0]\` in CHANGELOG.md.

Refs #69.