### PR TITLE
Raise CHD_MAX_FILE_SIZE to 1 TB for BD/PS3 ISOs

### DIFF
--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -83,8 +83,14 @@
 
 #define CHD_MAX_HUNK_SIZE				(128 * 1024 * 1024) /* hunk size probably shouldn't be more than 128MB */
 
-/* we're currently only using this for CD/DVDs, if we end up with more than 10GB data, it's probably invalid */
-#define CHD_MAX_FILE_SIZE				(10ULL * 1024 * 1024 * 1024)
+/* Sanity cap on logical (decompressed) CHD size. Large enough to cover
+ * any realistic disc image: BD50 PS3 ISOs (50 GB), arcade laserdisc
+ * CHDs, and future-proofing for larger optical formats. 1 TB is well
+ * under any integer-overflow threshold, and actual allocation safety
+ * is further bounded by CHD_MAX_HUNK_SIZE and the totalhunks check in
+ * header_read. Previously 10 GB, which rejected legitimate PS3 ISOs
+ * (#147). */
+#define CHD_MAX_FILE_SIZE				(1024ULL * 1024 * 1024 * 1024)
 
 #define COOKIE_VALUE				0xbaadf00d
 


### PR DESCRIPTION
## Summary

PR #147 reports that CHDs built from PS3 ISOs larger than ~10 GB fail to open with \`CHDERR_INVALID_DATA\`. Root cause flagged correctly by @treloret in the issue thread: \`CHD_MAX_FILE_SIZE\` is hard-capped at 10 GB, which predates BD50 / PS3 / dual-layer use.

\`\`\`c
/* we're currently only using this for CD/DVDs, if we end up with more than 10GB data, it's probably invalid */
#define CHD_MAX_FILE_SIZE   (10ULL * 1024 * 1024 * 1024)
\`\`\`

The check at \`header_read\` (line 1708) rejects any CHD whose logical size (\`hunkbytes * totalhunks\`) meets or exceeds that cap. BD50 PS3 ISOs (50 GB logical) hit it even though the on-disk CHD is small and the stored data verifies against the source SHA-1.

## Fix

Bump \`CHD_MAX_FILE_SIZE\` to 1 TB. Purely a sanity bound; does not weaken allocation safety:

- \`CHD_MAX_HUNK_SIZE\` (128 MB) already caps hunkbytes.
- \`totalhunks <= file_size * 8\` (added in #148) bounds \`map[]\` allocations against the actual file size.
- Hunk reads are lazy — the full logical size is never materialised in memory.

1 TB leaves headroom for larger optical formats and stays well under any 64-bit multiplication overflow threshold.

## Test plan

- [x] Clean build on Linux x86_64
- [x] Existing fuzz corpus still parses (no regression)

Closes #147.