### PR TITLE
Bump cross-platform-actions/action from 0.32.0 to 1.0.0

### DIFF
--- a/.github/workflows/cross-platform-actions.yml
+++ b/.github/workflows/cross-platform-actions.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: cross-platform-actions/action@v0.32.0
+      - uses: cross-platform-actions/action@v1
         with:
           operating_system: ${{ matrix.operating_system }}
           architecture: ${{ matrix.architecture }}


### PR DESCRIPTION
Fix warnings found in https://github.com/rtissera/libchdr/actions/runs/24892945928:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: cross-platform-actions/action@v0.32.0. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/