### PR TITLE
Fix Android build and add GitHub workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,21 @@
+name: Android
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        android_abi: [arm64-v8a, armeabi-v7a, x86, x86_64]
+        android_stl: [c++_shared, c++_static]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
+          -DANDROID_ABI=${{ matrix.android_abi }} -DANDROID_STL=${{ matrix.android_stl }}
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Release

--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -45,8 +45,10 @@
 #  ifndef _POSIX_C_SOURCE
 #    define _POSIX_C_SOURCE 200809L
 #  endif
-#  ifndef _FILE_OFFSET_BITS
-#    define _FILE_OFFSET_BITS 64
+#  ifndef __ANDROID__
+#    ifndef _FILE_OFFSET_BITS
+#      define _FILE_OFFSET_BITS 64
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
I am currently testing Flycast with libchdr v0.3.0 but I have a build failure with Android 21.
In the logs below, using Android 24 seems to be a way to solve this issue but removing the `_FILE_OFFSET_BITS` define maintains the compatibility with older SDK.
To prevent future build issues, I also added a GitHub workflow to build on Android.
```
  FAILED: external/libchdr/CMakeFiles/chdr-static.dir/src/libchdr_chd.c.o 
  /usr/bin/ccache /usr/local/lib/android/sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/bin/clang --target=armv7-none-linux-androideabi21 --sysroot=/usr/local/lib/android/sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DMINIZ_NO_ARCHIVE_APIS -DMINIZ_NO_DEFLATE_APIS -DMINIZ_NO_STDIO -DMINIZ_NO_TIME -DVERIFY_BLOCK_CRC=1 -DWANT_RAW_DATA_SECTOR=1 -DWANT_SUBCODE=1  -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__ -Werror=unguarded-availability -D_FORTIFY_SOURCE=2 -march=armv7-a -Wformat -Werror=format-security  -O2 -g -DNDEBUG -fPIC -MD -MT external/libchdr/CMakeFiles/chdr-static.dir/src/libchdr_chd.c.o -MF external/libchdr/CMakeFiles/chdr-static.dir/src/libchdr_chd.c.o.d -o external/libchdr/CMakeFiles/chdr-static.dir/src/libchdr_chd.c.o -c /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2182:6: error: 'ftello' is only available on Android 24 or newer [-Werror,-Wunguarded-availability]
   2182 |         p = core_stdio_ftell_impl(fp);
        |             ^~~~~~~~~~~~~~~~~~~~~
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2176:32: note: expanded from macro 'core_stdio_ftell_impl'
   2176 |         #define core_stdio_ftell_impl ftello
        |                                       ^~~~~~
  /usr/local/lib/android/sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/stdio.h:217:19: note: 'ftello' has been marked as being introduced in Android 24 here, but the deployment target is Android 21
    217 | __nodiscard off_t ftello(FILE* _Nonnull __fp) __RENAME(ftello64) __INTRODUCED_IN(24);
        |                   ^
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2182:6: note: enclose 'ftello' in a __builtin_available check to silence this warning
   2182 |         p = core_stdio_ftell_impl(fp);
        |             ^~~~~~~~~~~~~~~~~~~~~     
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2176:32: note: expanded from macro 'core_stdio_ftell_impl'
   2176 |         #define core_stdio_ftell_impl ftello
        |                                       ^~~~~~
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2183:2: error: 'fseeko' is only available on Android 24 or newer [-Werror,-Wunguarded-availability]
   2183 |         core_stdio_fseek_impl(fp, 0, SEEK_END);
        |         ^~~~~~~~~~~~~~~~~~~~~
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2175:32: note: expanded from macro 'core_stdio_fseek_impl'
   2175 |         #define core_stdio_fseek_impl fseeko
        |                                       ^~~~~~
  /usr/local/lib/android/sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/stdio.h:216:5: note: 'fseeko' has been marked as being introduced in Android 24 here, but the deployment target is Android 21
    216 | int fseeko(FILE* _Nonnull __fp, off_t __offset, int __whence) __RENAME(fseeko64) __INTRODUCED_IN(24);
        |     ^
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2183:2: note: enclose 'fseeko' in a __builtin_available check to silence this warning
   2183 |         core_stdio_fseek_impl(fp, 0, SEEK_END);
        |         ^~~~~~~~~~~~~~~~~~~~~                  
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2175:32: note: expanded from macro 'core_stdio_fseek_impl'
   2175 |         #define core_stdio_fseek_impl fseeko
        |                                       ^~~~~~
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2184:7: error: 'ftello' is only available on Android 24 or newer [-Werror,-Wunguarded-availability]
   2184 |         rv = core_stdio_ftell_impl(fp);
        |              ^~~~~~~~~~~~~~~~~~~~~
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2176:32: note: expanded from macro 'core_stdio_ftell_impl'
   2176 |         #define core_stdio_ftell_impl ftello
        |                                       ^~~~~~
  /usr/local/lib/android/sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/stdio.h:217:19: note: 'ftello' has been marked as being introduced in Android 24 here, but the deployment target is Android 21
    217 | __nodiscard off_t ftello(FILE* _Nonnull __fp) __RENAME(ftello64) __INTRODUCED_IN(24);
        |                   ^
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2184:7: note: enclose 'ftello' in a __builtin_available check to silence this warning
   2184 |         rv = core_stdio_ftell_impl(fp);
        |              ^~~~~~~~~~~~~~~~~~~~~     
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2176:32: note: expanded from macro 'core_stdio_ftell_impl'
   2176 |         #define core_stdio_ftell_impl ftello
        |                                       ^~~~~~
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2185:2: error: 'fseeko' is only available on Android 24 or newer [-Werror,-Wunguarded-availability]
   2185 |         core_stdio_fseek_impl(fp, p, SEEK_SET);
        |         ^~~~~~~~~~~~~~~~~~~~~
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2175:32: note: expanded from macro 'core_stdio_fseek_impl'
   2175 |         #define core_stdio_fseek_impl fseeko
        |                                       ^~~~~~
  /usr/local/lib/android/sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/stdio.h:216:5: note: 'fseeko' has been marked as being introduced in Android 24 here, but the deployment target is Android 21
    216 | int fseeko(FILE* _Nonnull __fp, off_t __offset, int __whence) __RENAME(fseeko64) __INTRODUCED_IN(24);
        |     ^
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2185:2: note: enclose 'fseeko' in a __builtin_available check to silence this warning
   2185 |         core_stdio_fseek_impl(fp, p, SEEK_SET);
        |         ^~~~~~~~~~~~~~~~~~~~~                  
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2175:32: note: expanded from macro 'core_stdio_fseek_impl'
   2175 |         #define core_stdio_fseek_impl fseeko
        |                                       ^~~~~~
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2216:9: error: 'fseeko' is only available on Android 24 or newer [-Werror,-Wunguarded-availability]
   2216 |         return core_stdio_fseek_impl((FILE*)file, offset, whence);
        |                ^~~~~~~~~~~~~~~~~~~~~
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2175:32: note: expanded from macro 'core_stdio_fseek_impl'
   2175 |         #define core_stdio_fseek_impl fseeko
        |                                       ^~~~~~
  /usr/local/lib/android/sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/stdio.h:216:5: note: 'fseeko' has been marked as being introduced in Android 24 here, but the deployment target is Android 21
    216 | int fseeko(FILE* _Nonnull __fp, off_t __offset, int __whence) __RENAME(fseeko64) __INTRODUCED_IN(24);
        |     ^
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2216:9: note: enclose 'fseeko' in a __builtin_available check to silence this warning
   2216 |         return core_stdio_fseek_impl((FILE*)file, offset, whence);
        |                ^~~~~~~~~~~~~~~~~~~~~                              
  /home/runner/work/flycast/flycast/external/libchdr/src/libchdr_chd.c:2175:32: note: expanded from macro 'core_stdio_fseek_impl'
   2175 |         #define core_stdio_fseek_impl fseeko
        |                                       ^~~~~~
  5 errors generated.
```
https://github.com/scribam/flycast/actions/runs/24997587480/job/73198554946#step:8:1027