### PR TITLE
Fix `chd_read_header_core_file_callbacks` 

### DIFF
--- a/src/libchdr_chd.c
+++ b/src/libchdr_chd.c
@@ -1365,8 +1365,12 @@ CHD_EXPORT chd_error chd_read_header_core_file_callbacks(const core_file_callbac
 	if (callbacks == NULL || header == NULL)
 		return CHDERR_INVALID_PARAMETER;
 
+	chd.cookie = COOKIE_VALUE;
 	chd.file.callbacks = callbacks;
 	chd.file.argp = (void*)user_data;
+	chd.file_size = core_fsize(&chd.file);
+	if ((int64_t)chd.file_size <= 0)
+		return CHDERR_INVALID_FILE;
 
 	/* attempt to read the header */
 	err = header_read(&chd);


### PR DESCRIPTION
Populate file size before calling `header_read` because now it performs check

```c
	/* totalhunks is used to size the map allocation; a malformed header
	 * can otherwise request multi-GB allocations for map[] even when the
	 * file itself is tiny. Every hunk map entry consumes at least one bit
	 * in the compressed on-disk map, so totalhunks cannot legitimately
	 * exceed file_size * 8. */
	if ((uint64_t)header->totalhunks > chd->file_size * 8)
		return CHDERR_INVALID_DATA;
```